### PR TITLE
Feature/14 add like functionality

### DIFF
--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -1,6 +1,10 @@
 class LikesController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_review
+  before_action :set_review, only: [ :create, :destroy ]
+
+  def index
+    @liked_reviews = current_user.liked_reviews.includes(:user, images_attachments: :blob)
+  end
 
   def create
     like = @review.likes.new(user: current_user)

--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -1,0 +1,22 @@
+class LikesController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_review
+
+  def create
+    like = @review.likes.new(user: current_user)
+    like.save
+    redirect_back fallback_location: @review
+  end
+
+  def destroy
+    like = @review.likes.find_by(user: current_user)
+    like&.destroy
+    redirect_back fallback_location: @review
+  end
+
+  private
+
+  def set_review
+    @review = Review.find(params[:review_id])
+  end
+end

--- a/app/models/like.rb
+++ b/app/models/like.rb
@@ -1,0 +1,6 @@
+class Like < ApplicationRecord
+  belongs_to :user
+  belongs_to :review
+
+  validates :user_id, uniqueness: { scope: :review_id, message: "同じレビューに2回以上いいねできません" }
+end

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -2,7 +2,7 @@ class Review < ApplicationRecord
   belongs_to :user
   has_many :releasable_items, dependent: :destroy
   has_many :comments, dependent: :destroy
-  
+
   # バリデーション
   validates :title, presence: true, length: { maximum: 100, message: "100文字以内で入力してください" }
   validates :content, presence: true, length: { maximum: 1000, message: "1000文字以内で入力してください" }

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -14,6 +14,7 @@ class Review < ApplicationRecord
   before_save :mark_empty_items_for_destruction
 
   has_many_attached :images
+  has_many :likes, dependent: :destroy
   validate :image_content_type
   validate :image_size
   validate :image_count_within_limit

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,8 @@ class User < ApplicationRecord
   has_many :reviews, dependent: :destroy
   has_one_attached :avatar
   has_many :comments, dependent: :destroy
+  has_many :likes, dependent: :destroy
+  has_many :liked_reviews, through: :likes, source: :review
 
   # 名前の長さは50文字以内
   validates :name, presence: true, length: { maximum: 50 }

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -13,11 +13,16 @@
 
   <!-- アイコン部分 -->
   <div class="flex items-center gap-4">
+    <!-- レビュー投稿 -->
     <%= link_to new_review_path, class: "flex items-center justify-center" do %>
       <span class="material-icons text-gray-600 text-3xl" aria-label="レビュー">rate_review</span>
     <% end %>
+    <!-- レビュー検索 -->
     <span class="material-icons text-gray-600 text-3xl" aria-label="検索">manage_search</span>
-    <span class="material-icons text-gray-600 text-3xl" aria-label="お気に入り">favorite_border</span>
+    <!-- いいね一覧 -->
+    <%= link_to liked_reviews_path, class: "flex items-center justify-center" do %>
+      <span class="material-icons text-gray-600 text-3xl" aria-label="いいね一覧">favorite_border</span>
+    <% end %>
 
     <% if user_signed_in? %>
       <%= link_to destroy_user_session_path, method: :delete, data: { turbo_method: :delete }, class: "flex items-center justify-center" do %>

--- a/app/views/likes/index.html.erb
+++ b/app/views/likes/index.html.erb
@@ -1,0 +1,68 @@
+<div class="container mx-auto px-10 py-10">
+  <h1 class="text-2xl font-bold mb-6">いいねした投稿一覧</h1>
+
+  <!-- グリッドレイアウト -->
+  <div class="grid grid-cols-1 md:grid-cols-2 gap-12">
+    <% @liked_reviews.each do |review| %>
+      <div class="card bg-white shadow-lg rounded-lg p-6">
+        
+        <!-- クリック可能な領域のラップ -->
+        <div class="clickable-area">
+          <%= link_to review_path(review), class: "block hover:no-underline text-inherit" do %>
+            
+            <!-- ユーザーアイコン・ユーザー名 -->
+            <div class="flex items-center mb-4">
+              <% if review.user.avatar.attached? %>
+                <%= image_tag review.user.resized_avatar, 
+                              class: "w-12 h-12 rounded-full object-cover", 
+                              alt: "User Avatar" %>
+              <% else %>
+                <span class="material-symbols-outlined text-gray-600 items-center justify-center">account_circle</span>
+              <% end %>
+              <div class="ml-4 text-gray-800 font-medium">
+                <p class="text-sm">
+                  <%= review.user.name %>
+                </p>
+              </div>
+            </div>
+
+            <!-- 投稿写真 -->
+            <div class="mb-4 grid grid-cols-3 gap-3">
+              <% if review.images.attached? %>
+                <% review.resized_images.each do |image| %>
+                  <%= image_tag image, alt: "投稿写真", class: "aspect-square rounded-md col-span-1 object-cover" %>
+                <% end %>
+              <% else %>
+                <% 3.times do %>
+                  <img src="https://via.placeholder.com/200" alt="投稿写真" class="aspect-square rounded-md col-span-1 object-cover">
+                <% end %>
+              <% end %>
+            </div>
+
+            <!-- 投稿タイトル -->
+            <div class="mb-2">
+              <h2 class="text-lg font-bold text-gray-900"><%= review.title %></h2>
+            </div>
+
+            <!-- 投稿本文 -->
+            <div class="mb-4 text-gray-700 text-sm">
+              <%= truncate(review.content, length: 100) %>
+            </div>
+          <% end %>
+        </div>
+
+        <!-- 区切り線 -->
+        <hr class="my-4 border-gray-300">
+
+        <!-- 商品画像・ブランド名・商品名 -->
+        <div class="flex items-center">
+          <img src="https://via.placeholder.com/100" alt="商品画像" class="w-16 h-16 object-cover rounded-md">
+          <div class="ml-4">
+            <p class="text-gray-800 text-sm font-medium">ブランド: MockBrand</p>
+            <p class="text-gray-800 text-sm font-medium">商品名: MockItem</p>
+          </div>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/reviews/index.html.erb
+++ b/app/views/reviews/index.html.erb
@@ -5,67 +5,79 @@
   <div class="grid grid-cols-1 md:grid-cols-2 gap-12">
     <% @reviews.each do |review| %>
       <div class="card bg-white shadow-lg rounded-lg p-6">
-        <%= link_to review_path(review), class: "block hover:no-underline text-inherit" do %>
-          
-          <!-- ユーザーアイコン・ユーザー名 -->
-          <div class="flex items-center mb-4">
-            <% if review.user.avatar.attached? %>
-              <%= image_tag review.user.resized_avatar, 
-                            class: "w-12 h-12 rounded-full object-cover", 
-                            alt: "User Avatar" %>
-            <% else %>
-              <span class="material-symbols-outlined text-gray-600 items-center justify-center">account_circle</span>
-            <% end %>
-            <div class="ml-4 text-gray-800 font-medium">
-              <p class="text-sm">
-                <%= review.user.name %>
-              </p>
+        
+        <!-- クリック可能な領域のラップ -->
+        <div class="clickable-area">
+          <%= link_to review_path(review), class: "block hover:no-underline text-inherit" do %>
+            
+            <!-- ユーザーアイコン・ユーザー名 -->
+            <div class="flex items-center mb-4">
+              <% if review.user.avatar.attached? %>
+                <%= image_tag review.user.resized_avatar, 
+                              class: "w-12 h-12 rounded-full object-cover", 
+                              alt: "User Avatar" %>
+              <% else %>
+                <span class="material-symbols-outlined text-gray-600 items-center justify-center">account_circle</span>
+              <% end %>
+              <div class="ml-4 text-gray-800 font-medium">
+                <p class="text-sm">
+                  <%= review.user.name %>
+                </p>
+              </div>
             </div>
-          </div>
 
-          <!-- 投稿写真 -->
-          <div class="mb-4 grid grid-cols-3 gap-3">
-            <% if review.images.attached? %>
-              <% review.resized_images.each do |image| %>
-                <%= image_tag image, alt: "投稿写真", class: "aspect-square rounded-md col-span-1 object-cover" %>
+            <!-- 投稿写真 -->
+            <div class="mb-4 grid grid-cols-3 gap-3">
+              <% if review.images.attached? %>
+                <% review.resized_images.each do |image| %>
+                  <%= image_tag image, alt: "投稿写真", class: "aspect-square rounded-md col-span-1 object-cover" %>
+                <% end %>
+              <% else %>
+                <% 3.times do %>
+                  <img src="https://via.placeholder.com/200" alt="投稿写真" class="aspect-square rounded-md col-span-1 object-cover">
+                <% end %>
+              <% end %>
+            </div>
+
+            <!-- 投稿タイトル -->
+            <div class="mb-2">
+              <h2 class="text-lg font-bold text-gray-900"><%= review.title %></h2>
+            </div>
+
+            <!-- 投稿本文 -->
+            <div class="mb-4 text-gray-700 text-sm">
+              <%= truncate(review.content, length: 100) %>
+            </div>
+          <% end %>
+        </div>
+
+        <!-- 区切り線 -->
+        <hr class="my-4 border-gray-300">
+
+        <!-- いいねボタン -->
+        <div class="flex justify-end mb-4">
+          <% if user_signed_in? %>
+            <% if review.likes.exists?(user: current_user) %>
+              <%= button_to review_like_path(review, current_user.likes.find_by(review: review)), method: :delete, class: "flex items-center text-red-500 hover:text-red-600" do %>
+                <span class="material-icons text-2xl">favorite</span>
               <% end %>
             <% else %>
-              <% 3.times do %>
-                <img src="https://via.placeholder.com/200" alt="投稿写真" class="aspect-square rounded-md col-span-1 object-cover">
+              <%= button_to review_likes_path(review), method: :post, class: "flex items-center text-gray-500 hover:text-red-500" do %>
+                <span class="material-icons text-2xl">favorite_border</span>
               <% end %>
             <% end %>
+          <% end %>
+        </div>
+
+        <!-- 商品画像・ブランド名・商品名 -->
+        <div class="flex items-center">
+          <img src="https://via.placeholder.com/100" alt="商品画像" class="w-16 h-16 object-cover rounded-md">
+          <div class="ml-4">
+            <p class="text-gray-800 text-sm font-medium">ブランド: MockBrand</p>
+            <p class="text-gray-800 text-sm font-medium">商品名: MockItem</p>
           </div>
-
-          <!-- 投稿タイトル -->
-          <div class="mb-2">
-            <h2 class="text-lg font-bold text-gray-900"><%= review.title %></h2>
-          </div>
-
-          <!-- 投稿本文 -->
-          <div class="mb-4 text-gray-700 text-sm">
-            <%= truncate(review.content, length: 100) %>
-          </div>
-        <% end %>
-
-      <!-- 区切り線 -->
-      <hr class="my-4 border-gray-300">
-
-      <!-- いいねボタン -->
-      <div class="flex justify-end mb-4">
-        <button class="flex items-center text-red-500 hover:text-red-600">
-          <span class="material-icons text-2xl">favorite_border</span>
-        </button>
-      </div>
-
-      <!-- 商品画像・ブランド名・商品名 -->
-      <div class="flex items-center">
-        <img src="https://via.placeholder.com/100" alt="商品画像" class="w-16 h-16 object-cover rounded-md">
-        <div class="ml-4">
-          <p class="text-gray-800 text-sm font-medium">ブランド: MockBrand</p>
-          <p class="text-gray-800 text-sm font-medium">商品名: MockItem</p>
         </div>
       </div>
-    </div>
     <% end %>
   </div>
   <div class="mt-8">

--- a/app/views/reviews/show.html.erb
+++ b/app/views/reviews/show.html.erb
@@ -74,6 +74,21 @@
     <!-- 区切り線 -->
     <hr class="my-6 border-gray-300">
 
+    <!-- いいねボタン -->
+    <div class="flex justify-end mb-4">
+      <% if user_signed_in? %>
+        <% if @review.likes.exists?(user: current_user) %>
+          <%= button_to review_like_path(@review, current_user.likes.find_by(review: @review)), method: :delete, class: "flex items-center text-red-500 hover:text-red-600" do %>
+            <span class="material-icons text-2xl">favorite</span>
+          <% end %>
+        <% else %>
+          <%= button_to review_likes_path(@review), method: :post, class: "flex items-center text-gray-500 hover:text-red-500" do %>
+            <span class="material-icons text-2xl">favorite_border</span>
+          <% end %>
+        <% end %>
+      <% end %>
+    </div>
+
     <!-- 商品情報 -->
     <div class="flex items-center">
       <% if @review.images.attached? %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,9 @@ Rails.application.routes.draw do
   get "home/index"
   root "home#index"
   resources :reviews do
-    resources :comments, only: [:create]
-    resources :likes, only: [:create, :destroy]
+    resources :comments, only: [ :create ]
+    resources :likes, only: [ :create, :destroy ]
   end
+
+  get "likes", to: "likes#index", as: "liked_reviews"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,5 +7,6 @@ Rails.application.routes.draw do
   root "home#index"
   resources :reviews do
     resources :comments, only: [:create]
+    resources :likes, only: [:create, :destroy]
   end
 end

--- a/db/migrate/20241223132931_create_likes.rb
+++ b/db/migrate/20241223132931_create_likes.rb
@@ -1,0 +1,10 @@
+class CreateLikes < ActiveRecord::Migration[7.2]
+  def change
+    create_table :likes do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :review, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_12_22_032042) do
+ActiveRecord::Schema[7.2].define(version: 2024_12_23_132931) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -52,6 +52,15 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_22_032042) do
     t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
+  create_table "likes", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "review_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["review_id"], name: "index_likes_on_review_id"
+    t.index ["user_id"], name: "index_likes_on_user_id"
+  end
+
   create_table "releasable_items", force: :cascade do |t|
     t.bigint "review_id", null: false
     t.string "name", null: false
@@ -87,6 +96,8 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_22_032042) do
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "comments", "reviews"
   add_foreign_key "comments", "users"
+  add_foreign_key "likes", "reviews"
+  add_foreign_key "likes", "users"
   add_foreign_key "releasable_items", "reviews"
   add_foreign_key "reviews", "users"
 end

--- a/spec/factories/likes.rb
+++ b/spec/factories/likes.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :like do
+    user
+    review
+  end
+end

--- a/spec/models/like_spec.rb
+++ b/spec/models/like_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe Like, type: :model do
+  let!(:user) { create(:user) }
+  let!(:review) { create(:review, user: user) }
+
+  describe 'バリデーション' do
+    context '正常系' do
+      it 'ユーザーとレビューがあれば有効であること' do
+        like = build(:like, user: user, review: review)
+        expect(like).to be_valid
+      end
+    end
+
+    context '異常系' do
+      it '同じユーザーとレビューの組み合わせが重複している場合は無効であること' do
+        create(:like, user: user, review: review)
+        duplicate_like = build(:like, user: user, review: review)
+        expect(duplicate_like).not_to be_valid
+        expect(duplicate_like.errors[:user_id]).to include('同じレビューに2回以上いいねできません')
+      end
+
+      it 'ユーザーが存在しない場合は無効であること' do
+        like_without_user = build(:like, user: nil, review: review)
+        expect(like_without_user).not_to be_valid
+      end
+
+      it 'レビューが存在しない場合は無効であること' do
+        like_without_review = build(:like, user: user, review: nil)
+        expect(like_without_review).not_to be_valid
+      end
+    end
+  end
+end


### PR DESCRIPTION
## タイトル

いいね機能の実装（非Ajax対応）

## 概要

レビューに対するいいね機能を実装。
ユーザーのいいねした投稿を一覧で確認できるページを追加し、ログイン状態に応じてUIを調整。

## 変更点

- Likeモデルを作成しReviewモデルに関連付け。
- LikesControllerにcreateおよびdestroyアクションを実装し、いいねの登録・削除処理を追加。
- `redirect_back`を使用し、いいね後に元のページへリダイレクト。
- レビュー一覧ページと詳細ページでいいねボタンを追加。
    - いいね済みの場合は赤いハートマークを表示。
    - ログインしていない場合、いいねボタンを非表示。
- `/likes` ページを追加し、ユーザーがいいねしたレビューの一覧を表示。
    - ページデザインはレビュー一覧と同様。

## 目的

レビューへのリアクションを可能にし、ユーザー間のエンゲージメントを向上させるため。

## 今後の課題

- いいね機能をAjax対応し、UXを向上させる。
- ページ内でソートやフィルタリング機能を追加し、利便性を高める。