### PR TITLE
Feature/107 add email password change

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -14,6 +14,10 @@ class ProfilesController < ApplicationController
   def edit_email
   end
 
+  # パスワード変更用フォームの表示
+  def edit_password
+  end
+
   # プロフィール情報（名前、自己紹介、アバター画像）の更新
   def update
     if @user.update(profile_params)
@@ -31,6 +35,17 @@ class ProfilesController < ApplicationController
     else
       flash.now[:alert] = "メールアドレスの更新に失敗しました。"
       render :edit_email, status: :unprocessable_entity
+    end
+  end
+
+  # パスワード更新処理
+  def update_password
+    if @user.update_with_password(password_update_params)
+      bypass_sign_in(@user) # サインイン状態を維持
+      redirect_to profile_path(@user), notice: "パスワードを変更しました！"
+    else
+      flash.now[:alert] = "パスワードの変更に失敗しました。"
+      render :edit_password, status: :unprocessable_entity
     end
   end
 
@@ -52,5 +67,9 @@ class ProfilesController < ApplicationController
 
   def email_update_params
     params.require(:user).permit(:email) # メールアドレスの変更を許可
+  end
+
+  def password_update_params
+    params.require(:user).permit(:current_password, :password, :password_confirmation)
   end
 end

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,8 +1,22 @@
-<p>Hello <%= @resource.email %>!</p>
+<p><%= @resource.name %>様</p>
 
-<p>Someone has requested a link to change your password. You can do this through the link below.</p>
+<p>この度は、MiniReをご利用いただきありがとうございます。</p>
 
-<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
+<p>以下のリンクをクリックすることで、パスワードの変更が可能です。</p>
 
-<p>If you didn't request this, please ignore this email.</p>
-<p>Your password won't change until you access the link above and create a new one.</p>
+<p>
+  <%= link_to 'パスワードを変更する', 
+               edit_password_url(@resource, reset_password_token: @token), 
+               style: 'color: #007bff; text-decoration: underline;' %>
+</p>
+
+<p>※リンクの有効期限は送信後6時間です。有効期限を過ぎた場合は、再度お手続きをお願いいたします。</p>
+
+<p>【ご注意】</p>
+<p>本メールに身に覚えの無い場合は、本メールを破棄していただきますようお願いいたします。</p>
+
+<p>MiniRe サポートチーム</p>
+
+<p>-------------------------------------------------</p>
+<p>このメールは送信専用です。返信いただいてもお答えできませんのでご了承ください。</p>
+<p>-------------------------------------------------</p>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,25 +1,86 @@
-<h2>Change your password</h2>
+<div class="flex h-screen items-center justify-center bg-gray-100">
+  <div class="w-full max-w-lg px-2">
+    <!-- 新しいパスワード設定カード -->
+    <h2 class="text-center mt-2 mb-4 text-xl font-semibold">
+      新しいパスワードを設定
+    </h2>
+    <div class="card bg-white shadow-lg p-6 rounded-lg">
+      <div class="card-body">
+        <%= form_with model: resource, url: password_path(resource_name), method: :put, local: true do |f| %>
+          <!-- 新しいパスワード入力 -->
+          <div class="form-control mb-4">
+            <label class="label">
+              <span class="label-text text-base font-medium">新しいパスワード</span>
+            </label>
+            <%= f.password_field :password, placeholder: "新しいパスワードを入力してください", class: "input input-bordered w-full h-14 text-base placeholder:text-sm" %>
+          </div>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
-  <%= f.hidden_field :reset_password_token %>
+          <!-- 新しいパスワード（確認） -->
+          <div class="form-control mb-4">
+            <label class="label">
+              <span class="label-text text-base font-medium">新しいパスワード（確認）</span>
+            </label>
+            <%= f.password_field :password_confirmation, placeholder: "新しいパスワードを再入力してください", class: "input input-bordered w-full h-14 text-base placeholder:text-sm" %>
+          </div>
 
-  <div class="field">
-    <%= f.label :password, "New password" %><br />
-    <% if @minimum_password_length %>
-      <em>(<%= @minimum_password_length %> characters minimum)</em><br />
-    <% end %>
-    <%= f.password_field :password, autofocus: true, autocomplete: "new-password" %>
+          <!-- リセット用トークン（hidden field） -->
+          <%= f.hidden_field :reset_password_token %>
+
+          <!-- 送信ボタン -->
+          <div class="form-control mt-4">
+            <%= f.submit "パスワードを変更", class: "btn bg-customBlue text-white border-0 hover:bg-blue-500 w-full py-3 text-lg" %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+
+    <!-- ログインページリンク -->
+    <p class="text-center mt-4 text-sm">
+      ログインページに戻る場合は
+      <%= link_to "こちらをクリック", new_session_path(resource_name), class: "link link-primary font-semibold text-sm" %>
+    </p>
   </div>
+</div>
+<div class="flex h-screen items-center justify-center bg-gray-100">
+  <div class="w-full max-w-lg px-2">
+    <!-- 新しいパスワード設定カード -->
+    <h2 class="text-center mt-2 mb-4 text-xl font-semibold">
+      新しいパスワードを設定
+    </h2>
+    <div class="card bg-white shadow-lg p-6 rounded-lg">
+      <div class="card-body">
+        <%= form_with model: resource, url: password_path(resource_name), method: :put, local: true do |f| %>
+          <!-- 新しいパスワード入力 -->
+          <div class="form-control mb-4">
+            <label class="label">
+              <span class="label-text text-base font-medium">新しいパスワード</span>
+            </label>
+            <%= f.password_field :password, placeholder: "新しいパスワードを入力してください", class: "input input-bordered w-full h-14 text-base placeholder:text-sm" %>
+          </div>
 
-  <div class="field">
-    <%= f.label :password_confirmation, "Confirm new password" %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+          <!-- 新しいパスワード（確認） -->
+          <div class="form-control mb-4">
+            <label class="label">
+              <span class="label-text text-base font-medium">新しいパスワード（確認）</span>
+            </label>
+            <%= f.password_field :password_confirmation, placeholder: "新しいパスワードを再入力してください", class: "input input-bordered w-full h-14 text-base placeholder:text-sm" %>
+          </div>
+
+          <!-- リセット用トークン（hidden field） -->
+          <%= f.hidden_field :reset_password_token %>
+
+          <!-- 送信ボタン -->
+          <div class="form-control mt-4">
+            <%= f.submit "パスワードを変更", class: "btn bg-customBlue text-white border-0 hover:bg-blue-500 w-full py-3 text-lg" %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+
+    <!-- ログインページリンク -->
+    <p class="text-center mt-4 text-sm">
+      ログインページに戻る場合は
+      <%= link_to "こちらをクリック", new_session_path(resource_name), class: "link link-primary font-semibold text-sm" %>
+    </p>
   </div>
-
-  <div class="actions">
-    <%= f.submit "Change my password" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,16 +1,32 @@
-<h2>Forgot your password?</h2>
+<div class="flex h-screen items-center justify-center bg-gray-100">
+  <div class="w-full max-w-lg px-2">
+    <!-- パスワードリセットカード -->
+    <h2 class="text-center mt-2 mb-4 text-xl font-semibold">
+      パスワードをリセット
+    </h2>
+    <div class="card bg-white shadow-lg p-6 rounded-lg">
+      <div class="card-body">
+        <%= form_with model: resource, url: password_path(resource_name), local: true do |f| %>
+          <!-- メールアドレス入力フィールド -->
+          <div class="form-control mb-4">
+            <label class="label">
+              <span class="label-text text-base font-medium">メールアドレス</span>
+            </label>
+            <%= f.email_field :email, placeholder: "メールアドレスを入力してください", class: "input input-bordered w-full h-14 text-base placeholder:text-sm" %>
+          </div>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+          <!-- 送信ボタン -->
+          <div class="form-control mt-4">
+            <%= f.submit "リセットリンクを送信", class: "btn bg-customBlue text-white border-0 hover:bg-blue-500 w-full py-3 text-lg" %>
+          </div>
+        <% end %>
+      </div>
+    </div>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+    <!-- ログインページリンク -->
+    <p class="text-center mt-4 text-sm">
+      ログインページに戻る場合は
+      <%= link_to "こちらをクリック", new_session_path(resource_name), class: "link link-primary font-semibold text-sm" %>
+    </p>
   </div>
-
-  <div class="actions">
-    <%= f.submit "Send me reset password instructions" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -55,6 +55,10 @@
             <%= link_to "メールアドレスの変更", edit_email_profile_path(@user), class: "text-blue-500 hover:text-blue-700 underline" %>
           </div>
 
+          <div class="form-control mt-4">
+            <%= link_to "パスワードの変更", edit_password_profile_path(@user), class: "text-blue-500 hover:text-blue-700 underline" %>
+          </div>
+
           <!-- 更新ボタン -->
           <div class="form-control mt-4">
             <%= f.submit "更新する", 

--- a/app/views/profiles/edit_password.html.erb
+++ b/app/views/profiles/edit_password.html.erb
@@ -1,0 +1,57 @@
+<div class="flex h-screen items-center justify-center bg-gray-100">
+  <div class="w-full max-w-lg px-2">
+    <h2 class="text-center mt-2 mb-4 text-xl font-semibold">
+      パスワード変更
+    </h2>
+    <div class="card bg-white shadow-lg p-6 rounded-lg">
+      <div class="card-body">
+        <%= form_with model: @user, url: update_password_profile_path(@user), method: :patch, local: true do |f| %>
+          <!-- 現在のパスワード -->
+          <div class="form-control mb-4">
+            <label class="label">
+              <span class="label-text text-base font-medium">現在のパスワード</span>
+            </label>
+            <%= f.password_field :current_password, placeholder: "現在のパスワードを入力してください", 
+                                 class: "input input-bordered w-full h-14 text-base placeholder:text-sm" %>
+            <% if @user.errors[:current_password].present? %>
+              <p class="text-red-500 text-sm mt-1"><%= @user.errors[:current_password].first %></p>
+            <% end %>
+          </div>
+
+          <!-- 新しいパスワード -->
+          <div class="form-control mb-4">
+            <label class="label">
+              <span class="label-text text-base font-medium">新しいパスワード</span>
+            </label>
+            <%= f.password_field :password, placeholder: "新しいパスワードを入力してください", 
+                                 class: "input input-bordered w-full h-14 text-base placeholder:text-sm" %>
+            <% if @user.errors[:password].present? %>
+              <p class="text-red-500 text-sm mt-1"><%= @user.errors[:password].first %></p>
+            <% end %>
+          </div>
+
+          <!-- 新しいパスワード確認 -->
+          <div class="form-control mb-4">
+            <label class="label">
+              <span class="label-text text-base font-medium">新しいパスワード（確認用）</span>
+            </label>
+            <%= f.password_field :password_confirmation, placeholder: "新しいパスワードを再入力してください", 
+                                 class: "input input-bordered w-full h-14 text-base placeholder:text-sm" %>
+            <% if @user.errors[:password_confirmation].present? %>
+              <p class="text-red-500 text-sm mt-1"><%= @user.errors[:password_confirmation].first %></p>
+            <% end %>
+          </div>
+
+          <!-- 更新ボタン -->
+          <div class="form-control mt-4">
+            <%= f.submit "パスワードを更新", class: "btn bg-customBlue text-white border-0 hover:bg-blue-500 w-full py-3 text-lg" %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+    <p class="text-center mt-4 text-sm">
+      プロフィールページに戻る場合は
+      <%= link_to "こちらをクリック", profile_path(@user), class: "link link-primary font-semibold text-sm" %>
+    </p>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,8 @@ Rails.application.routes.draw do
       get :likes
       get :edit_email
       patch :update_email
+      get :edit_password
+      patch :update_password
     end
   end
 


### PR DESCRIPTION
## **タイトル**

パスワードリセット機能の実装（未ログイン時対応 & ログイン状態でのパスワード変更対応）

---

### **概要**

未ログイン時に「パスワードを忘れた場合」のリンクからリセットリンクを送信し、新しいパスワードを設定できる機能を実装しました。また、ログイン状態ではメール確認なしでパスワードを更新できる機能も実装しました。

---

### **変更点**

1. **ログイン画面の変更**
    - 「パスワードを忘れた場合」のリンクを追加。
    - リンクをクリックするとパスワードリセット画面に遷移。
2. **パスワードリセット機能**
    - 未ログイン時、登録済みメールアドレスにパスワードリセット用リンクを送信。
    - リンクをクリックすると新しいパスワードを入力できる画面に遷移。
3. **ログイン状態でのパスワード変更**
    - プロフィール編集画面に「パスワード変更」リンクを追加。
    - リンク先で現在のパスワード、新しいパスワードを入力して更新可能。
    - メール確認なしでパスワードを更新。
4. **パスワードリセットメール**
    - リセット用リンクを含むメールを送信。
    - メール文面をユーザーにとってわかりやすい形式に修正（リンク有効期限を6時間に設定）。
5. **エラーハンドリング**
    - 無効なリセットトークンや登録されていないメールアドレスの場合に適切なフラッシュメッセージを表示。
    - ログイン状態でのパスワード更新時、バリデーションエラーが適切に表示されるよう対応。

---

### **目的**

未ログインユーザーが安全かつ簡単にパスワードをリセットできるようにすることで、利便性を向上。また、ログイン状態のユーザーが手軽にパスワードを変更できるようにすることで、アカウント管理を容易にする。

---

### **動作確認**

- **未ログイン時**
    - 登録済みメールアドレスでリセットリンクが送信されることを確認。
    - 無効なトークンや未登録のメールアドレスの場合にエラーが適切に表示されることを確認。
- **ログイン時**
    - プロフィール編集画面からパスワードが正常に更新されることを確認。
    - バリデーションエラー時にエラーメッセージが正しく表示されることを確認。
- 本番環境でのメール送信設定が適切に動作することを確認。

---

### **今後の課題**

1. リセット完了後のリダイレクト先やフラッシュメッセージの文言を再検討。