### PR TITLE
利用規約とプライバシーポリシーのページを追加し、フッターにリンクを設定

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,0 +1,7 @@
+class StaticPagesController < ApplicationController
+  def terms_of_service
+  end
+
+  def privacy_policy
+  end
+end

--- a/app/helpers/static_pages_helper.rb
+++ b/app/helpers/static_pages_helper.rb
@@ -1,0 +1,2 @@
+module StaticPagesHelper
+end

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -3,8 +3,8 @@
     <!-- Footer Links -->
     <div class="flex flex-col md:flex-row items-center gap-4">
       <%= link_to 'お問い合わせ', 'https://docs.google.com/forms/d/e/1FAIpQLSekpXn40Ny_dXzf-HF85rMtgz67KkxKMzny7y8xRVp9K8-MNA/viewform?usp=header', target: '_blank', rel: 'noopener noreferrer', class: 'hover:underline' %>
-      <a href="#" class="hover:underline">利用規約</a>
-      <a href="#" class="hover:underline">プライバシーポリシー</a>
+      <%= link_to '利用規約', terms_of_service_path, class: 'hover:underline' %>
+      <%= link_to 'プライバシーポリシー', privacy_policy_path, class: 'hover:underline' %>
     </div>
     <!-- Footer Copy -->
     <div class="flex items-center gap-4 mt-4 md:mt-0">

--- a/app/views/static_pages/privacy_policy.html.erb
+++ b/app/views/static_pages/privacy_policy.html.erb
@@ -1,0 +1,100 @@
+<article class="max-w-3xl mx-auto p-6 bg-white shadow-lg rounded-lg">
+  <section class="mb-8">
+    <h1 class="text-3xl font-bold text-center text-gray-800">プライバシーポリシー</h1>
+    <p class="mt-4 text-gray-600">
+      MiniRe（以下「当方」といいます）は、お客様の個人情報を適切に保護することを重視しています。<br>
+      このプライバシーポリシーは、当方が取得する情報、その利用目的、管理方法などについて定めたものです。
+    </p>
+  </section>
+
+  <!-- お客様から取得する情報 -->
+  <div class="mb-8">
+    <h2 class="text-2xl font-semibold text-gray-800 border-b border-gray-300 pb-2">お客様から取得する情報</h2>
+    <ul class="list-disc pl-5 mt-4 text-gray-700 space-y-2" style="list-style: disc; padding-left: 1.25rem;">
+      <li>氏名（ニックネームやペンネームを含む）</li>
+      <li>メールアドレス</li>
+      <li>写真や動画</li>
+      <li>外部サービスでお客様が利用するID、その他外部サービスのプライバシー設定によりお客様が連携先に開示を認めた情報</li>
+      <li>Cookie（クッキー）を用いて生成された識別情報</li>
+      <li>当方ウェブサイトの滞在時間、入力履歴、購買履歴などの行動履歴</li>
+      <li>お客様の位置情報</li>
+    </ul>
+  </div>
+
+  <!-- お客様の情報を利用する目的 -->
+  <section class="mb-8">
+    <h2 class="text-2xl font-semibold text-gray-800 border-b border-gray-300 pb-2">お客様の情報を利用する目的</h2>
+    <ul class="list-decimal pl-5 mt-4 text-gray-700 space-y-2" style="list-style: decimal; padding-left: 1.25rem;">
+      <li>当方サービスに関する登録の受付、お客様の本人確認、認証のため</li>
+      <li>お客様の当方サービスの利用履歴を管理するため</li>
+      <li>当方サービスにおけるお客様の行動履歴を分析し、当方サービスの維持改善に役立てるため</li>
+      <li>当方サービスに関するご案内をするため</li>
+      <li>お客様からのお問い合わせに対応するため</li>
+      <li>当方の規約や法令に違反する行為に対応するため</li>
+      <li>当方サービスの変更、提供中止、終了、契約解除をご連絡するため</li>
+      <li>当方規約の変更等を通知するため</li>
+      <li>その他、当方サービスの提供、維持、保護および改善のため</li>
+    </ul>
+  </section>
+
+  <!-- クッキーの使用に関する情報 -->
+  <section class="mb-8">
+    <h2 class="text-2xl font-semibold text-gray-800 border-b border-gray-300 pb-2">クッキーの使用に関する情報</h2>
+    <p class="mt-4 text-gray-700">
+      当サイトでは、ユーザーの利便性向上やトラフィック分析のためにクッキーを使用しています。<br>
+      特定のリンクをクリックすると、第三者（例：Amazon）のクッキーがユーザーのブラウザに設定される場合があります。
+    </p>
+  </section>
+
+  <!-- 第三者提供 -->
+  <section class="mb-8">
+    <h2 class="text-2xl font-semibold text-gray-800 border-b border-gray-300 pb-2">第三者提供</h2>
+    <p class="mt-4 text-gray-700">
+      当方は、お客様から取得する情報のうち、個人データ（個人情報保護法第16条第3項）に該当するものについて、<br>
+      あらかじめお客様の同意を得ずに第三者（日本国外にある者を含む）に提供しません。ただし、以下の場合を除きます。
+    </p>
+    <ul class="list-disc pl-5 mt-4 text-gray-700 space-y-2" style="list-style: disc; padding-left: 1.25rem;">
+      <li>個人データの取扱いを外部に委託する場合</li>
+      <li>当方や当方サービスが買収された場合</li>
+      <li>事業パートナーと共同利用する場合（具体的な共同利用内容は別途公表します。）</li>
+      <li>その他、法律によって合法的に第三者提供が許されている場合</li>
+    </ul>
+  </section>
+
+  <!-- アクセス解析ツール -->
+  <section class="mb-8">
+    <h2 class="text-2xl font-semibold text-gray-800 border-b border-gray-300 pb-2">アクセス解析ツール</h2>
+    <p class="mt-4 text-gray-700">
+      当方は、サービス改善のために「Googleアナリティクス」を利用しています。<br>
+      Googleアナリティクスは、Cookieを使用してトラフィックデータを匿名で収集します。このデータは個人を特定するものではありません。<br>
+      お客様は、ブラウザの設定によりCookieを無効にすることで、これらの情報収集を拒否できます。
+    </p>
+    <p class="mt-4 text-gray-700">
+      詳しくは以下をご参照ください。<br>
+      <a href="https://marketingplatform.google.com/about/analytics/terms/jp/" class="text-blue-500 underline" target="_blank">
+        Google アナリティクス利用規約
+      </a>
+    </p>
+  </section>
+
+  <!-- お問い合わせ -->
+  <section>
+    <h2 class="text-2xl font-semibold text-gray-800 border-b border-gray-300 pb-2">お問い合わせ</h2>
+    <p class="mt-4 text-gray-700">
+      お客様の情報の開示、訂正、利用停止、削除をご希望の場合は、以下の連絡先にご連絡ください。
+    </p>
+    <ul class="list-disc pl-5 mt-4 text-gray-700 space-y-2" style="list-style: disc; padding-left: 1.25rem;">
+      <li>
+        お問い合わせフォーム:
+        <a href="https://docs.google.com/forms/d/e/1FAIpQLSekpXn40Ny_dXzf-HF85rMtgz67KkxKMzny7y8xRVp9K8-MNA/viewform?usp=header" 
+           class="text-blue-500 underline" target="_blank">
+          Googleフォームにアクセス
+        </a>
+      </li>
+    </ul>
+    <p class="mt-4 text-gray-700">
+      お問い合わせの際は、ご本人確認のため運転免許証のご提示など、当方が指定する方法により確認を行います。<br>
+      また、情報開示請求については、1件あたり1,000円の事務手数料を申し受けます。
+    </p>
+  </section>
+</article>

--- a/app/views/static_pages/terms_of_service.html.erb
+++ b/app/views/static_pages/terms_of_service.html.erb
@@ -1,0 +1,105 @@
+<article class="max-w-3xl mx-auto p-6 bg-white shadow-lg rounded-lg">
+  <section class="mb-8">
+    <h1 class="text-3xl font-bold text-center text-gray-800">MiniRe利用規約</h1>
+    <p class="mt-4 text-gray-600">
+      この利用規約（以下、「本規約」といいます）は、MiniRe（以下、「本サービス」といいます）の利用条件を定めるものです。<br>
+      本サービスを利用する全てのユーザー（以下、「ユーザー」といいます）は、本規約に同意したものとみなされます。
+    </p>
+  </section>
+
+  <!-- 第1条 適用範囲 -->
+  <section class="mb-8">
+    <h2 class="text-2xl font-semibold text-gray-800 border-b border-gray-300 pb-2">第1条 適用範囲</h2>
+    <ul class="list-disc pl-5 mt-4 text-gray-700" style="list-style: disc; padding-left: 1.25rem;">
+      <li>本規約は、本サービスを利用するすべてのユーザーに適用されます。</li>
+      <li>ユーザーが本サービスを利用することにより、本規約に同意したものとみなされます。</li>
+    </ul>
+  </section>
+
+  <!-- 第2条 利用登録 -->
+  <section class="mb-8">
+    <h2 class="text-2xl font-semibold text-gray-800 border-b border-gray-300 pb-2">第2条 利用登録</h2>
+    <ul class="list-disc pl-5 mt-4 text-gray-700" style="list-style: disc; padding-left: 1.25rem;">
+      <li>本サービスを利用するためには、本規約に同意し、運営者が定める手続に従い利用登録を行う必要があります。</li>
+      <li>利用登録の申請が承認された時点で、ユーザーは本サービスを利用する権利を取得します。</li>
+    </ul>
+  </section>
+
+  <!-- 第3条 登録の拒否 -->
+  <section class="mb-8">
+    <h2 class="text-2xl font-semibold text-gray-800 border-b border-gray-300 pb-2">第3条 登録の拒否</h2>
+    <p class="mt-4 text-gray-700">
+      運営者は、以下のいずれかに該当する場合、利用登録を拒否することがあります。
+    </p>
+    <ul class="list-disc pl-5 mt-4 text-gray-700" style="list-style: disc; padding-left: 1.25rem;">
+      <li>虚偽の情報を提供した場合</li>
+      <li>過去に本規約に違反したことがある場合</li>
+      <li>その他、運営者が利用登録を不適当と判断した場合</li>
+    </ul>
+  </section>
+
+  <!-- 第4条 未成年者の利用 -->
+  <section class="mb-8">
+    <h2 class="text-2xl font-semibold text-gray-800 border-b border-gray-300 pb-2">第4条 未成年者の利用</h2>
+    <ul class="list-disc pl-5 mt-4 text-gray-700" style="list-style: disc; padding-left: 1.25rem;">
+      <li>未成年者が本サービスを利用する場合、事前に法定代理人の同意を得る必要があります。</li>
+      <li>同意を得ずに利用した場合は、成年に達した時点で過去の利用行為を追認したものとみなします。</li>
+    </ul>
+  </section>
+
+  <!-- 第5条 ログイン情報の管理 -->
+  <section class="mb-8">
+    <h2 class="text-2xl font-semibold text-gray-800 border-b border-gray-300 pb-2">第5条 ログイン情報の管理</h2>
+    <ul class="list-disc pl-5 mt-4 text-gray-700" style="list-style: disc; padding-left: 1.25rem;">
+      <li>ユーザーは、自己の責任においてログイン情報を適切に管理するものとします。</li>
+      <li>ログイン情報が第三者に使用されたことにより生じた損害について、運営者は故意または重大な過失がない限り責任を負いません。</li>
+    </ul>
+  </section>
+
+  <!-- 第6条 コンテンツの利用 -->
+  <section class="mb-8">
+    <h2 class="text-2xl font-semibold text-gray-800 border-b border-gray-300 pb-2">第6条 コンテンツの利用</h2>
+    <ul class="list-disc pl-5 mt-4 text-gray-700" style="list-style: disc; padding-left: 1.25rem;">
+      <li>本サービスで提供される全てのコンテンツは、個人的な利用のみに限定されます。</li>
+      <li>提供されたコンテンツの利用条件に従い、適切に利用してください。</li>
+      <li>本サービスのコンテンツを商業的に利用することは禁止されています。</li>
+    </ul>
+  </section>
+
+  <!-- 第7条 禁止行為 -->
+  <section class="mb-8">
+    <h2 class="text-2xl font-semibold text-gray-800 border-b border-gray-300 pb-2">第7条 禁止行為</h2>
+    <p class="mt-4 text-gray-700">
+      ユーザーは、本サービスの利用にあたり、以下の行為を行ってはなりません。
+    </p>
+    <ul class="list-disc pl-5 mt-4 text-gray-700" style="list-style: disc; padding-left: 1.25rem;">
+      <li>法令または公序良俗に反する行為</li>
+      <li>他人の権利または利益を侵害する行為</li>
+      <li>他人に不利益または損害を与える行為</li>
+      <li>サービスの運営を妨害する行為</li>
+      <li>その他、運営者が不適切と判断する行為</li>
+    </ul>
+  </section>
+  
+  <!-- 第8条 利用制限および登録解除 -->
+  <section class="mb-8">
+    <h2 class="text-2xl font-semibold text-gray-800 border-b border-gray-300 pb-2">第8条 利用制限および登録解除</h2>
+    <p class="mt-4 text-gray-700">
+      運営者は、以下の場合にユーザーの利用を制限し、または登録を解除することができます。
+    </p>
+    <ul class="list-disc pl-5 mt-4 text-gray-700" style="list-style: disc; padding-left: 1.25rem;">
+      <li>本規約に違反した場合</li>
+      <li>登録情報に虚偽が含まれている場合</li>
+      <li>サービスの利用が悪意によるものと判断された場合</li>
+    </ul>
+  </section>
+
+  <!-- 第9条 準拠法および管轄 -->
+  <section class="mb-8">
+    <h2 class="text-2xl font-semibold text-gray-800 border-b border-gray-300 pb-2">第9条 準拠法および管轄</h2>
+    <ul class="list-disc pl-5 mt-4 text-gray-700" style="list-style: disc; padding-left: 1.25rem;">
+      <li>本規約の解釈および適用には、日本法を準拠法とします。</li>
+      <li>本サービスに関連して生じた紛争については、運営者の所在地を管轄する裁判所を第一審の専属的合意管轄裁判所とします。</li>
+    </ul>
+  </section>
+</article>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,9 @@ Rails.application.routes.draw do
 
   resources :items, only: [ :index, :show ]
 
+  get "/terms_of_service", to: "static_pages#terms_of_service"
+  get "/privacy_policy", to: "static_pages#privacy_policy"
+
   namespace :admin do
     resources :items, only: [ :index, :edit, :update ]
   end

--- a/spec/helpers/static_pages_helper_spec.rb
+++ b/spec/helpers/static_pages_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the StaticPagesHelper. For example:
+#
+# describe StaticPagesHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe StaticPagesHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/static_pages_spec.rb
+++ b/spec/requests/static_pages_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "StaticPages", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end


### PR DESCRIPTION
### **タイトル**

利用規約ページの実装および箇条書き表示の改善

---

### **概要**

以下の内容を含む利用規約ページを新たに実装しました。また、デザインと表示に関する調整を行いました。

---

### **変更内容**

- **利用規約ページの追加**
    - `app/views/pages/terms.html.erb` ファイルを作成し、利用規約ページを実装しました。
    - 各条文をセクションごとに分けて整理しました。
- **箇条書きのスタイル修正**
    - CSSのグローバルリセットにより箇条書きが非表示になる問題を解決。
    - `<ul>` に `style="list-style: disc; padding-left: 1.25rem;"` を明示的に指定し、箇条書きを正しく表示。
- **コードの簡略化**
    - ヘッダーがグローバルに定義されている場合、ページ固有のヘッダー部分を削除。
    - ページ内にタイトルと説明文を補完し、SEOにも対応。