### PR TITLE
商品に説明フィールドを追加し、関連するバリデーションと表示を更新

### DIFF
--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -39,7 +39,7 @@ end
   private
 
   def item_params
-    params.require(:item).permit(:name, :manufacturer, :price, :amazon_url, :asin, images: [], remove_images: [])
+    params.require(:item).permit(:name, :manufacturer, :price, :amazon_url, :asin, :description,images: [], remove_images: [])
   end
 
   def authenticate_admin!

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -6,6 +6,7 @@ class Item < ApplicationRecord
   validates :name, length: { minimum: 1, maximum: 50 }
   validates :amazon_url, format: { with: URI.regexp(%w[http https]), message: "正しいURL形式を入力してください。" }, allow_blank: true
   validate :image_content_type
+  validates :description, length: { maximum: 1000 }, allow_blank: true
 
   # ファイル形式のバリデーション
   def image_content_type

--- a/app/views/admin/items/edit.html.erb
+++ b/app/views/admin/items/edit.html.erb
@@ -17,6 +17,10 @@
       <%= f.label :amazon_url, "Amazon URL", class: "block text-sm font-medium text-gray-700" %>
       <%= f.text_field :amazon_url, class: "input input-bordered w-full h-12 text-lg" %>
     </div>
+    <div class="mb-4">
+      <%= f.label :description, "商品説明", class: "block text-sm font-medium text-gray-700" %>
+      <%= f.text_area :description, class: "input input-bordered w-full h-32 text-lg" %>
+    </div>
     <!-- 商品画像の編集 -->
     <div class="mb-4">
       <h2 class="text-lg font-medium text-gray-700">商品画像</h2>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -5,6 +5,9 @@
   <div class="max-w-6xl mx-auto bg-white px-6 sm:px-8 py-6 sm:py-8 shadow-md rounded-md space-y-8">
     <!-- 商品詳細セクション -->
     <div class="flex flex-col md:flex-row gap-8 sm:gap-12 items-start">
+    <%
+=begin
+    %>
       <!-- 左側: 商品画像 (横スクロール) -->
       <div class="w-full md:w-1/2">
         <div class="flex space-x-4 p-2  overflow-x-auto">
@@ -24,12 +27,18 @@
           <% end %>
         </div>
       </div>
+    <%
+=end
+    %>
 
       <!-- 右側: 商品情報 -->
       <div class="flex flex-col w-full md:w-1/2 space-y-4 sm:space-y-6 px-4 sm:px-8">
         <h1 class="text-2xl font-bold text-gray-800"><%= @item.name %></h1>
         <p class="text-gray-600 text-base sm:text-lg">販売元: <%= @item.manufacturer || '情報がありません' %></p>
+        <p class="text-gray-600 text-base sm:text-lg">商品説明: <%= simple_format(@item.description) || '情報がありません' %></p>
+        <!--
         <p class="text-gray-600 text-base sm:text-lg">価格: <%= @item.price.present? ? "¥#{number_to_currency(@item.price, unit: '', delimiter: ',')}" : '情報がありません' %></p>
+        -->
 
         <% if @item.amazon_url.present? %>
           <%= link_to "Amazonで購入する", @item.amazon_url, 

--- a/app/views/shared/_review_card.html.erb
+++ b/app/views/shared/_review_card.html.erb
@@ -58,29 +58,36 @@
   </div>
 
   <!-- 商品情報 -->
-  <% if review.item.present? %>
-    <div class="flex items-center">
-      <%= link_to item_path(review.item), class: "flex items-center w-full hover:bg-gray-100 p-2 rounded-md" do %>
-        <% if review.item.images.attached? %>
-          <%= image_tag review.item.resized_images.first,
-                        alt: "商品画像",
-                        class: "w-16 h-16 object-cover rounded-md" %>
-        <% else %>
-          <%= image_tag "logo.png", alt: "MiniRe", class: "w-16 h-16 object-cover" %>
-        <% end %>
-        <div class="ml-4">
-          <% if review.item.manufacturer.present? %>
-            <p class="text-xm text-gray-500"><%= review.item.manufacturer %></p>
-          <% end %>
-          <% if review.item.name.present? %>
-            <p class="text-sm text-gray-800 font-medium"><%= review.item.name %></p>
-          <% end %>
-        </div>
+
+
+<% if review.item.present? %>
+  <div class="flex items-center">
+    <%= link_to item_path(review.item), class: "flex items-center w-full p-2 rounded-md hover:bg-gray-100 cursor-pointer transition duration-200" do %>
+      <!-- 商品画像（現在コメントアウト） -->
+      <!--
+      <% if review.item.images.attached? %>
+        <%= image_tag review.item.resized_images.first,
+                      alt: "商品画像",
+                      class: "w-16 h-16 object-cover rounded-md" %>
+      <% else %>
+        <%= image_tag "logo.png", alt: "MiniRe", class: "w-16 h-16 object-cover rounded-md" %>
       <% end %>
-    </div>
-  <% else %>
-    <div class="flex items-center text-gray-500">
-      <p>商品情報がありません</p>
-    </div>
-  <% end %>
+      -->
+      <div class="ml-4 flex-1">
+        <% if review.item.manufacturer.present? %>
+          <p class="text-sm text-gray-500"><%= review.item.manufacturer %></p>
+        <% end %>
+        <% if review.item.name.present? %>
+          <p class="text-md text-gray-800 font-medium underline hover:underline"><%= "#{review.item.name}の詳細" %></p>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+<% else %>
+  <div class="flex items-center text-gray-500">
+    <p>商品情報がありません</p>
+  </div>
+<% end %>
+
+
 </div>

--- a/db/migrate/20250209001934_add_description_to_items.rb
+++ b/db/migrate/20250209001934_add_description_to_items.rb
@@ -1,0 +1,5 @@
+class AddDescriptionToItems < ActiveRecord::Migration[7.2]
+  def change
+    add_column :items, :description, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_01_07_115736) do
+ActiveRecord::Schema[7.2].define(version: 2025_02_09_001934) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -68,6 +68,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_07_115736) do
     t.datetime "last_updated_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "description"
   end
 
   create_table "likes", force: :cascade do |t|


### PR DESCRIPTION
## 概要

amazonの情報に関する部分をコメントアウトし、
商品データに説明フィールドを追加し、関連するバリデーションと表示を更新。

## 変更点

- **amazonの情報に関する部分をコメントアウト**
    - amazonの商品画像、価格部分をコメントアウト
- **説明フィールドの追加**
    - 商品モデルに説明フィールドを追加
- **バリデーションの更新**
    - 説明フィールドに対するバリデーションを追加
- **表示の更新**
    - 商品詳細ページと一覧ページに説明フィールドを表示

## 目的

amazonアソシエイトに申請するに当たり、amazon審査にひっかからないようにするため。
商品の詳細情報を充実させるため、説明フィールドを追加し、バリデーションと表示を更新。

## 今後の課題

1. **説明フィールドの活用**
    - 商品説明を充実させ、ユーザーにとって有益な情報を提供
2. **バリデーションの強化**
    - 入力データの品質を保つため、バリデーションを適宜見直し
3. **ユーザーエクスペリエンスの向上**
    - 説明フィールドの表示方法を工夫し、ユーザーにとって見やすい情報提供を心がける
4. **amazonアソシエイト機能の活用**
    - amazonからの商品情報を活用し、ユーザーにわかりやすい情報を提供する。