### PR TITLE
レビュー表示の改善：商品画像の表示を一時的に変更

### DIFF
--- a/app/views/reviews/show.html.erb
+++ b/app/views/reviews/show.html.erb
@@ -93,7 +93,7 @@
     <!-- 商品情報 -->
     <div class="flex items-center mt-6">
       <%= link_to item_path(@review.item), class: "flex items-center w-full hover:bg-gray-100 p-2 rounded-md" do %>
-        <!-- 商品画像 -->
+        <!-- 商品画像
         <% if @review.item.images.attached? %>
           <%= image_tag @review.item.resized_images.first,
                         alt: "商品画像",
@@ -101,15 +101,21 @@
         <% else %>
           <%= image_tag "logo.png", alt: "MiniRe", class: "w-16 h-16 object-cover" %>
         <% end %>
+         -->
         <!-- 商品情報 -->
         <div class="ml-4">
           <!-- ブランド名 -->
           <% if @review.item.manufacturer.present? %>
-            <p class="text-xm text-gray-500"><%= @review.item.manufacturer %></p>
+            <p class="text-sm text-gray-500"><%= @review.item.manufacturer %></p>
           <% end %>
-          <!-- 商品名 -->
+          <!-- 商品名
           <% if @review.item.name.present? %>
-            <p class="text-sm text-gray-800 font-medium"><%= @review.item.name %></p>
+            <p class="text-md text-gray-800 font-medium"><%= @review.item.name %></p>
+          <% end %>
+           -->
+          <!--amazonの商品画像が使えないため、一時的に下記で詳細ページへ遷移を示す-->
+          <% if @review.item.name.present? %>
+            <p class="text-md text-gray-800 font-medium underline"><%= "#{@review.item.name}の詳細" %></p>
           <% end %>
         </div>
       <% end %>

--- a/app/views/shared/_review_card.html.erb
+++ b/app/views/shared/_review_card.html.erb
@@ -77,8 +77,9 @@
         <% if review.item.manufacturer.present? %>
           <p class="text-sm text-gray-500"><%= review.item.manufacturer %></p>
         <% end %>
+        <!--amazonの商品画像が使えないため、一時的に下記で詳細ページへ遷移を示す-->
         <% if review.item.name.present? %>
-          <p class="text-md text-gray-800 font-medium underline hover:underline"><%= "#{review.item.name}の詳細" %></p>
+          <p class="text-md text-gray-800 font-medium underline"><%= "#{review.item.name}の詳細" %></p>
         <% end %>
       </div>
     <% end %>


### PR DESCRIPTION
## 概要

レビュー表示の改善：商品画像の表示を一時的に変更

## 変更点

- **商品画像の表示を一時的に変更**
    - レビュー表示において商品画像の表示を一時的に非表示。

## 目的

amazonアソシエイトの申請にあたって、商品画像を一時的に使わないようにするため。　