### PR TITLE
コメント機能のAjax化

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,33 +1,51 @@
 class CommentsController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_comment, only: [ :destroy ]
+  before_action :find_commentable, only: %i[create]
+  before_action :set_comment, only: %i[destroy]
 
   def create
-    @review = Review.find(params[:review_id])
-    @comment = @review.comments.build(comment_params.merge(user: current_user))
-    if @comment.save
-      redirect_to @review, notice: "コメントを投稿しました！"
-    else
-      redirect_to @review, alert: "コメントの投稿に失敗しました。"
+    @comment = @commentable.comments.build(comment_params.merge(user: current_user))
+    @comments = @commentable.comments.includes(:user)
+
+    respond_to do |format|
+      if @comment.save
+        format.turbo_stream
+        format.html { redirect_to @commentable }
+      else
+        # format.turbo_stream do
+        #   flash.now[:danger] = t('defaults.message.not_created', item: Comment.model_name.human)
+        # render turbo_stream: [
+        #   turbo_stream.replace("flash_messages", partial: "shared/flash_messages"),
+        # ]
+        # end
+        format.html { redirect_to @commentable }
+      end
     end
   end
 
   def destroy
     if @comment.user == current_user
       @comment.destroy
-      redirect_to @comment.review, notice: "コメントを削除しました。"
+      respond_to do |format|
+        format.turbo_stream
+        format.html { redirect_to @comment.commentable, notice: "コメントを削除しました。" }
+      end
     else
-      redirect_to @comment.review, alert: "コメントの削除権限がありません。"
+      redirect_to @comment.commentable, alert: "コメントの削除権限がありません。"
     end
   end
 
   private
 
   def set_comment
-    @comment = Comment.find(params[:id])
+    @comment = current_user.comments.find(params[:id])
   end
 
   def comment_params
     params.require(:comment).permit(:content)
+  end
+
+  def find_commentable
+    @commentable = Review.find(params[:review_id])
   end
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -35,6 +35,29 @@ class CommentsController < ApplicationController
     end
   end
 
+  def edit
+    @comment = Comment.find_by(id: params[:id])
+  end
+
+  def update
+    respond_to do |format|
+      if @comment.update(comment_params)
+        format.turbo_stream { flash.now[:notice] = "コメントを編集しました。" }
+        format.html { redirect_to @comment.commentable,
+                      flash: { success: t('defaults.message.updated', item: Comment.model_name.human) } }
+      else
+        format.turbo_stream do
+          flash.now[:warning] = t('defaults.message.not_updated', item: Comment.model_name.human)
+          render turbo_stream: [
+            turbo_stream.replace("flash_messages", partial: "shared/flash_messages"),
+          ]
+        end
+        format.html { redirect_to @comment.commentable,
+                      flash: { danger: t('defaults.message.not_updated', item: Comment.model_name.human) } }
+      end
+    end
+  end
+
   private
 
   def set_comment

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,11 +1,10 @@
 class CommentsController < ApplicationController
   before_action :authenticate_user!
-  before_action :find_review, only: %i[create edit]
+  before_action :find_review, only: %i[create edit destroy]
   before_action :find_comment, only: %i[destroy edit update]
 
   def create
     @comment = @review.comments.build(comment_params.merge(user: current_user))
-    # @comments = @review.comments.includes(:user)
 
     respond_to do |format|
       if @comment.save

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -9,8 +9,8 @@ class CommentsController < ApplicationController
 
     respond_to do |format|
       if @comment.save
-        format.turbo_stream
-        format.html { redirect_to @commentable }
+        format.turbo_stream { flash.now[:notice] = "コメントを投稿しました。" }
+        format.html { redirect_to @commentable, notice: "コメントを投稿しました。" }
       else
         # format.turbo_stream do
         #   flash.now[:danger] = t('defaults.message.not_created', item: Comment.model_name.human)

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -27,7 +27,7 @@ class CommentsController < ApplicationController
     if @comment.user == current_user
       @comment.destroy
       respond_to do |format|
-        format.turbo_stream
+        format.turbo_stream  { flash.now[:notice] = "コメントを削除しました。" }
         format.html { redirect_to @comment.commentable, notice: "コメントを削除しました。" }
       end
     else

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -45,6 +45,7 @@ end
   def show
     @review = Review.find(params[:id])
     @comments = @review.comments.includes(:user)
+    @comment = @review.comments.new
   end
 
   def index

--- a/app/javascript/controllers/comment_controller.js
+++ b/app/javascript/controllers/comment_controller.js
@@ -1,0 +1,9 @@
+// import { Controller } from "@hotwired/stimulus";
+// 
+// export default class extends Controller {
+//   static targets = ["form", "input"];
+// 
+//   resetForm() {
+//     this.inputTarget.value = ""; // 入力フィールドをリセット
+//   }
+// }

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -7,6 +7,9 @@ import { application } from "./application"
 // import AutocompleteController from "./autocomplete_controller"
 // application.register("autocomplete", AutocompleteController)
 
+// import CommentController from "./comment_controller";
+// application.register("comment", CommentController);
+
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
 

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,7 +1,7 @@
 <%= turbo_frame_tag dom_id(comment) do %>
-  <li class="flex items-start space-x-4">
+  <li class="flex items-start space-x-4 py-2">
     <!-- ユーザーのアバター -->
-    <% if comment .user.avatar.attached? %>
+    <% if comment.user.avatar.attached? %>
       <%= image_tag comment.user.avatar.variant(resize_to_fill: [40, 40]), class: "rounded-full w-10 h-10" %>
     <% else %>
       <span class="material-symbols-outlined text-gray-600 flex items-center justify-center w-10 h-10" style="font-size: 40px;">
@@ -15,24 +15,25 @@
         <span class="font-semibold text-sm"><%= comment.user.name %></span>
         <span class="text-gray-500 text-xs ml-2"><%= time_ago_in_words(comment.created_at) %>前</span>
       </div>
-      <p class="text-gray-800 text-sm"><%= comment.content %></p>
+      <p class="text-gray-800 text-sm"><%= safe_join(comment.content.split("\n"), tag(:br)) %></p>
 
       <% if comment.user == current_user %>
-        <%= link_to review_comment_path(comment.review, comment), 
-            method: :delete,
-            id: "button-delete-#{comment.id}",
-            data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" },
-            class: "flex items-center gap-1 hover:text-red-600" do %>
-          削除
-        <% end %>
-      <% end %>
+        <div class="flex space-x-4 justify-end mt-2">
+          <!-- 編集ボタン -->
+          <%= link_to edit_review_comment_path(comment.review, comment), class: "flex items-center text-gray-600 hover:text-blue-800 text-sm" do %>
+            <span class="material-symbols-outlined text-base">edit</span> 編集
+          <% end %>
 
-      <% if comment.user == current_user %>
-        <!--コメントの編集-->
-        <%= link_to edit_review_comment_path(comment.review, comment), class: "flex items-center gap-1 hover:text-blue-600" do %>
-          編集
-        <% end %>
+          <!-- 削除ボタン -->
+          <%= link_to review_comment_path(comment.review, comment), 
+              method: :delete,
+              id: "button-delete-#{comment.id}",
+              data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" },
+              class: "flex items-center text-gray-600 hover:text-red-800 text-sm" do %>
+            <span class="material-symbols-outlined text-base">delete</span> 削除
+          <% end %>
+        </div>
       <% end %>
     </div>
-</li>
+  </li>
 <% end %>

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -26,9 +26,12 @@
           削除
         <% end %>
       <% end %>
-      <!--コメントの編集-->
-      <%= link_to edit_review_comment_path(comment.review, comment), class: "flex items-center gap-1 hover:text-blue-600" do %>
-        編集
+
+      <% if comment.user == current_user %>
+        <!--コメントの編集-->
+        <%= link_to edit_review_comment_path(comment.review, comment), class: "flex items-center gap-1 hover:text-blue-600" do %>
+          編集
+        <% end %>
       <% end %>
     </div>
 </li>

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,4 +1,4 @@
-<li class="flex items-start space-x-4">
+<li id="<%= dom_id(comment) %>" class="flex items-start space-x-4">
   <!-- ユーザーのアバター -->
   <% if comment.user.avatar.attached? %>
     <%= image_tag comment.user.avatar.variant(resize_to_fill: [40, 40]), class: "rounded-full w-10 h-10" %>
@@ -19,6 +19,7 @@
     <% if comment.user == current_user %>
       <%= link_to review_comment_path(comment.review, comment), 
           method: :delete,
+          id: "button-delete-#{comment.id}",
           data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" },
           class: "flex items-center gap-1 hover:text-red-600" do %>
         削除

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,29 +1,35 @@
-<li id="<%= dom_id(comment) %>" class="flex items-start space-x-4">
-  <!-- ユーザーのアバター -->
-  <% if comment.user.avatar.attached? %>
-    <%= image_tag comment.user.avatar.variant(resize_to_fill: [40, 40]), class: "rounded-full w-10 h-10" %>
-  <% else %>
-    <span class="material-symbols-outlined text-gray-600 flex items-center justify-center w-10 h-10" style="font-size: 40px;">
-      account_circle
-    </span>
-  <% end %>
-
-  <!-- コメント内容 -->
-  <div class="flex-1">
-    <div class="flex items-center mb-1">
-      <span class="font-semibold text-sm"><%= comment.user.name %></span>
-      <span class="text-gray-500 text-xs ml-2"><%= time_ago_in_words(comment.created_at) %>前</span>
-    </div>
-    <p class="text-gray-800 text-sm"><%= comment.content %></p>
-
-    <% if comment.user == current_user %>
-      <%= link_to review_comment_path(comment.review, comment), 
-          method: :delete,
-          id: "button-delete-#{comment.id}",
-          data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" },
-          class: "flex items-center gap-1 hover:text-red-600" do %>
-        削除
-      <% end %>
+<%= turbo_frame_tag dom_id(comment) do %>
+  <li class="flex items-start space-x-4">
+    <!-- ユーザーのアバター -->
+    <% if comment .user.avatar.attached? %>
+      <%= image_tag comment.user.avatar.variant(resize_to_fill: [40, 40]), class: "rounded-full w-10 h-10" %>
+    <% else %>
+      <span class="material-symbols-outlined text-gray-600 flex items-center justify-center w-10 h-10" style="font-size: 40px;">
+        account_circle
+      </span>
     <% end %>
-  </div>
+
+    <!-- コメント内容 -->
+    <div class="flex-1">
+      <div class="flex items-center mb-1">
+        <span class="font-semibold text-sm"><%= comment.user.name %></span>
+        <span class="text-gray-500 text-xs ml-2"><%= time_ago_in_words(comment.created_at) %>前</span>
+      </div>
+      <p class="text-gray-800 text-sm"><%= comment.content %></p>
+
+      <% if comment.user == current_user %>
+        <%= link_to review_comment_path(comment.review, comment), 
+            method: :delete,
+            id: "button-delete-#{comment.id}",
+            data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" },
+            class: "flex items-center gap-1 hover:text-red-600" do %>
+          削除
+        <% end %>
+      <% end %>
+      <!--コメントの編集-->
+      <%= link_to edit_review_comment_path(comment.review, comment), class: "flex items-center gap-1 hover:text-blue-600" do %>
+        編集
+      <% end %>
+    </div>
 </li>
+<% end %>

--- a/app/views/comments/_comments.html.erb
+++ b/app/views/comments/_comments.html.erb
@@ -2,4 +2,4 @@
   <% comments.each do |comment| %>
    <%= render 'comments/comment', comment: comment %>
   <% end %>
-<% end %>
+<% end %> 

--- a/app/views/comments/_comments.html.erb
+++ b/app/views/comments/_comments.html.erb
@@ -1,0 +1,5 @@
+<%= turbo_frame_tag 'comments' do %>
+  <% comments.each do |comment| %>
+   <%= render 'comments/comment', comment: comment %>
+  <% end %>
+<% end %>

--- a/app/views/comments/_comments.html.erb
+++ b/app/views/comments/_comments.html.erb
@@ -1,5 +1,5 @@
 <%= turbo_frame_tag 'comments' do %>
   <% comments.each do |comment| %>
-   <%= render 'comments/comment', comment: comment %>
+    <%= render 'comments/comment', comment: comment %>
   <% end %>
-<% end %> 
+<% end %>

--- a/app/views/comments/_comments_count.html.erb
+++ b/app/views/comments/_comments_count.html.erb
@@ -1,3 +1,3 @@
 <%= turbo_frame_tag "comments_count" do %>
-  コメント数: <%= comments.count %>
+  <%= @review.comments.count %>件のコメント</h2>
 <% end %>

--- a/app/views/comments/_comments_count.html.erb
+++ b/app/views/comments/_comments_count.html.erb
@@ -1,0 +1,3 @@
+<%= turbo_frame_tag "comments_count" do %>
+  コメント数: <%= comments.count %>
+<% end %>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,11 +1,18 @@
-<%= turbo_frame_tag 'comment_form' do %>
- <%= form_with model: [review, comment], id: "#{dom_id(comment)}_form" do |form| %>
-  <div class="mb-3">
-    <%= form.label :comment, "コメント" %>
-    <%= form.text_area :content, class: 'form-control', id: 'js-new-comment-body' %>
+<% if user_signed_in? %>
+  <%= turbo_frame_tag 'comment_form' do %>
+    <%= form_with model: [review, comment], id: "#{dom_id(comment)}_form" do |form| %>
+      <div class="form-control mb-2 mt-2">
+        <%= form.text_area :content, 
+          class: "textarea textarea-bordered w-full text-lg placeholder:text-sm", 
+          placeholder: "コメントする" %>
+      </div>
+      <div class="text-right mt-2">
+        <%= form.submit "コメント", class: "btn bg-customBlue text-white border-0 hover:bg-blue-500 btn-sm inline-block align-middle"%>
+      </div>
+    <% end %>
+  <% end %>
+<% else %>
+  <div>
+    <%= link_to "ログインしてコメントする", new_user_session_path, class: "btn bg-customBlue text-white border-0 hover:bg-blue-500" %>
   </div>
-  <div class="text-end">
-    <%= form.submit class: 'btn btn-primary btn-sm' %>
-  </div>
- <% end %>
 <% end %>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,0 +1,18 @@
+<%= turbo_frame_tag 'comment_form' do %>
+<%= form_with model: comment, url: review_comments_path(comment.review_id || review), id: "#{dom_id(comment)}_form", local: true do |form| %>
+
+  <% comment.errors.full_messages.each do |message| %>
+    <div class="alert alert-danger alert-dismissible fade show" role="alert">
+      <%= message %>
+      <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+  <% end %>
+  <div class="mb-3">
+    <%= form.label :content %>
+    <%= form.text_area :content, class: 'form-control', id: 'js-new-comment-body' %>
+  </div>
+  <div class="text-end">
+    <%= form.submit class: 'btn btn-primary btn-sm' %>
+  </div>
+ <% end %>
+<% end %>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,16 +1,11 @@
 <%= turbo_frame_tag 'comment_form' do %>
-  <div data-controller="comment">
-    <%= form_with model: Comment.new, url: review_comments_path(review), id: "comment_form", data: { action: "turbo:submit-end->comment#resetForm" } do |form| %>
-      <%= form.text_area :content, class: 'form-control', id: 'js-new-comment-body', data: { comment_target: "input" } %>
-      <%= form.submit "送信", class: 'btn btn-primary btn-sm' %>
-    <% end %>
+ <%= form_with model: [review, comment], id: "#{dom_id(comment)}_form" do |form| %>
+  <div class="mb-3">
+    <%= form.label :comment, "コメント" %>
+    <%= form.text_area :content, class: 'form-control', id: 'js-new-comment-body' %>
   </div>
-
-  <% comment.errors.full_messages.each do |message| %>
-    <div class="alert alert-danger alert-dismissible fade show" role="alert">
-      <%= message %>
-      <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-    </div>
-  <% end %>
-
+  <div class="text-end">
+    <%= form.submit class: 'btn btn-primary btn-sm' %>
+  </div>
+ <% end %>
 <% end %>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,5 +1,10 @@
 <%= turbo_frame_tag 'comment_form' do %>
-<%= form_with model: comment, url: review_comments_path(comment.review_id || review), id: "#{dom_id(comment)}_form", local: true do |form| %>
+  <div data-controller="comment">
+    <%= form_with model: Comment.new, url: review_comments_path(review), id: "comment_form", data: { action: "turbo:submit-end->comment#resetForm" } do |form| %>
+      <%= form.text_area :content, class: 'form-control', id: 'js-new-comment-body', data: { comment_target: "input" } %>
+      <%= form.submit "送信", class: 'btn btn-primary btn-sm' %>
+    <% end %>
+  </div>
 
   <% comment.errors.full_messages.each do |message| %>
     <div class="alert alert-danger alert-dismissible fade show" role="alert">
@@ -7,12 +12,5 @@
       <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
     </div>
   <% end %>
-  <div class="mb-3">
-    <%= form.label :content %>
-    <%= form.text_area :content, class: 'form-control', id: 'js-new-comment-body' %>
-  </div>
-  <div class="text-end">
-    <%= form.submit class: 'btn btn-primary btn-sm' %>
-  </div>
- <% end %>
+
 <% end %>

--- a/app/views/comments/create.turbo_stream.erb
+++ b/app/views/comments/create.turbo_stream.erb
@@ -4,4 +4,8 @@
   <%= render "form", review: @comment.review, comment: Comment.new %>
 <% end %>
 
+<%= turbo_stream.update "comments_count" do %>
+  <%= render "comments_count", review: @review %>
+<% end %>
+
 <%= turbo_stream.append "comments", partial: "comments/comment", locals: { comment: @comment } %>

--- a/app/views/comments/create.turbo_stream.erb
+++ b/app/views/comments/create.turbo_stream.erb
@@ -1,4 +1,4 @@
-<%= turbo_stream.replace "flash_message", partial: "shared/flash_message_turbo" %>
+<%= turbo_stream.replace "flash_message", partial: "shared/flash_message_turbo"%>
 
 <%= turbo_stream.replace "#{dom_id(Comment.new)}_form" do %>
   <%= render "form", review: @comment.review, comment: Comment.new %>

--- a/app/views/comments/create.turbo_stream.erb
+++ b/app/views/comments/create.turbo_stream.erb
@@ -1,6 +1,6 @@
 <%= turbo_stream.replace "flash_message", partial: "shared/flash_message_turbo" %>
 
-<%= turbo_stream.replace "#{dom_id(@comment.review)}_form" do %>
+<%= turbo_stream.replace "#{dom_id(Comment.new)}_form" do %>
   <%= render "form", review: @comment.review, comment: Comment.new %>
 <% end %>
 

--- a/app/views/comments/create.turbo_stream.erb
+++ b/app/views/comments/create.turbo_stream.erb
@@ -1,6 +1,5 @@
-<%= turbo_stream.replace "#{dom_id(Comment.new)}_form" do %>
-  <%= render "comments/form", review: @review, comment: @comment %>
-<% end %>
+<%= turbo_stream.replace "flash_message", partial: "shared/flash_message_turbo" %>
+
 <%= turbo_stream.replace "#{dom_id(@comment.review)}_form" do %>
   <%= render "form", review: @comment.review, comment: Comment.new %>
 <% end %>

--- a/app/views/comments/create.turbo_stream.erb
+++ b/app/views/comments/create.turbo_stream.erb
@@ -1,0 +1,8 @@
+<%= turbo_stream.replace "#{dom_id(Comment.new)}_form" do %>
+  <%= render "comments/form", review: @review, comment: @comment %>
+<% end %>
+<%= turbo_stream.replace "#{dom_id(@comment.review)}_form" do %>
+  <%= render "form", review: @comment.review, comment: Comment.new %>
+<% end %>
+
+<%= turbo_stream.append "comments", partial: "comments/comment", locals: { comment: @comment } %>

--- a/app/views/comments/destroy.turbo_stream.erb
+++ b/app/views/comments/destroy.turbo_stream.erb
@@ -1,2 +1,5 @@
 <%= turbo_stream.replace "flash_message", partial: "shared/flash_message_turbo" %>
 <%= turbo_stream.remove @comment %>
+<%= turbo_stream.update "comments_count" do %>
+  <%= render "comments_count", review: @review%>
+<% end %>

--- a/app/views/comments/destroy.turbo_stream.erb
+++ b/app/views/comments/destroy.turbo_stream.erb
@@ -1,0 +1,2 @@
+<%= turbo_stream.replace "flash_message", partial: "shared/flash_message_turbo" %>
+<%= turbo_stream.remove @comment %>

--- a/app/views/comments/edit.html.erb
+++ b/app/views/comments/edit.html.erb
@@ -1,4 +1,6 @@
 <%= turbo_frame_tag dom_id(@comment) do %>
       <%= render 'comments/form', review: @comment.review, comment: @comment %>
-      <%= link_to "キャンセル", @comment.review, class: 'btn btn-secondary btn-sm float-end mt-2' %>
+      <div  class="text-right mt-2">
+            <%= link_to "キャンセル", @comment.review, class: 'btn btn-outline border px-4 py-2 rounded-md hover:bg-gray-200 hover:text-gray-900 btn-sm'%>
+      </div>
 <% end %>

--- a/app/views/comments/edit.html.erb
+++ b/app/views/comments/edit.html.erb
@@ -1,0 +1,4 @@
+<%= turbo_frame_tag dom_id(@comment) do %>
+      <%= render 'comments/form', review: @comment.review, comment: @comment %>
+      <%= link_to "キャンセル", @comment.review, class: 'btn btn-secondary btn-sm float-end mt-2' %>
+<% end %>

--- a/app/views/comments/update.turbo_stream.erb
+++ b/app/views/comments/update.turbo_stream.erb
@@ -1,0 +1,4 @@
+<%= turbo_stream.replace "flash_message", partial: "shared/flash_message_turbo" %>
+<%= turbo_stream.replace dom_id(@comment) do %>
+  <%= render "comment", comment: @comment %>
+<% end %>

--- a/app/views/reviews/show.html.erb
+++ b/app/views/reviews/show.html.erb
@@ -124,7 +124,7 @@
   </div>
 
   <div class="mt-8">
-    <h2 class="text-xl font-bold mb-6"><%= @review.comments.count %>件のコメント</h2>
+    <h2 id = "comments_count" class="text-xl font-bold mb-6"><%= @review.comments.count %>件のコメント</h2>
 
     <div id="flash_message" class="mb-5">
       <%= render "shared/flash_message_turbo" %>

--- a/app/views/reviews/show.html.erb
+++ b/app/views/reviews/show.html.erb
@@ -126,12 +126,15 @@
   <div class="mt-8">
     <h2 class="text-xl font-bold mb-6"><%= @review.comments.count %>件のコメント</h2>
 
+    <div id="flash_message" class="mb-5">
+      <%= render "shared/flash_message_turbo" %>
+    </div>
+
     <div id="comment_form">
-    <%= render partial: "comments/form", locals: { review: @review, comment: @comment } %>
+    <%= render "comments/form", review: @review, comment: @comment %>
     </div>
 
     <!--非同期でのコメントの表示-->
-    <!--下記でうまくcommentがわたっていない?-->
     <div id="comments">
       <%= render "comments/comments", comments: @comments %>
     </div>

--- a/app/views/reviews/show.html.erb
+++ b/app/views/reviews/show.html.erb
@@ -124,25 +124,15 @@
   </div>
 
   <div class="mt-8">
-  <h2 class="text-xl font-bold mb-6"><%= @review.comments.count %>件のコメント</h2>
+    <h2 class="text-xl font-bold mb-6"><%= @review.comments.count %>件のコメント</h2>
 
-  <% if user_signed_in? %>
-    <div class="flex mb-6 items-start">
-      <!-- コメント投稿フォーム -->
-      <div class="flex-1">
-        <%= form_with model: [@review, Comment.new], local: true, class: "flex flex-col space-y-3" do |f| %>
-          <%= f.text_area :content, rows: 3, placeholder: "コメントを入力してください", class: "w-full p-3 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500" %>
-          <%= f.submit "投稿する", class: "self-end btn bg-customBlue text-white border-0 hover:bg-blue-500 px-4 py-2 text-base rounded-md" %>
-        <% end %>
-      </div>
+    <div id="comment_form">
+    <%= render partial: "comments/form", locals: { review: @review, comment: @comment } %>
     </div>
-  <% else %>
-    <p class="text-gray-600 mb-6">コメントを投稿するにはログインしてください。</p>
-  <% end %>
 
-  <!-- コメント一覧 -->
-  <ul class="space-y-6">
-    <%= render @review.comments %>
-  </ul>
-</div>
+    <!--非同期でのコメントの表示-->
+    <!--下記でうまくcommentがわたっていない?-->
+    <div id="comments">
+      <%= render "comments/comments", comments: @comments %>
+    </div>
 </div>

--- a/app/views/shared/_flash_message_turbo.html.erb
+++ b/app/views/shared/_flash_message_turbo.html.erb
@@ -1,0 +1,20 @@
+<% flash.each do |key, value| %>
+  <% css_class = case key.to_sym
+    when :notice then "bg-blue-100 border-l-4 border-blue-500 text-blue-700 flex items-center p-4 rounded-md"
+    when :alert then "bg-red-100 border-l-4 border-red-500 text-red-700 flex items-center p-4 rounded-md"
+    else "bg-gray-100 border-l-4 border-gray-500 text-gray-700 flex items-center p-4 rounded-md"
+  end %>
+
+  <div class="<%= css_class %>">
+    <div class="mr-3">
+      <% if key.to_sym == :notice %>
+        <span class="material-icons text-blue-500">info</span>
+      <% elsif key.to_sym == :alert %>
+        <span class="material-icons text-red-500">error</span>
+      <% else %>
+        <span class="material-icons text-gray-500">notifications</span>
+      <% end %>
+    </div>
+    <div><%= value %></div>
+  </div>
+<% end %>

--- a/app/views/shared/_flash_message_turbo.html.erb
+++ b/app/views/shared/_flash_message_turbo.html.erb
@@ -1,20 +1,24 @@
-<% flash.each do |key, value| %>
-  <% css_class = case key.to_sym
-    when :notice then "bg-blue-100 border-l-4 border-blue-500 text-blue-700 flex items-center p-4 rounded-md"
-    when :alert then "bg-red-100 border-l-4 border-red-500 text-red-700 flex items-center p-4 rounded-md"
-    else "bg-gray-100 border-l-4 border-gray-500 text-gray-700 flex items-center p-4 rounded-md"
-  end %>
+<div id="flash_message" class="<%= flash.any? ? '' : 'hidden' %>">
+  <% if flash.any? %>
+    <% flash.each do |key, value| %>
+      <% css_class = case key.to_sym
+        when :notice then "bg-blue-100 border-l-4 border-blue-500 text-blue-700 flex items-center p-4 rounded-md"
+        when :alert then "bg-red-100 border-l-4 border-red-500 text-red-700 flex items-center p-4 rounded-md"
+        else "bg-gray-100 border-l-4 border-gray-500 text-gray-700 flex items-center p-4 rounded-md"
+      end %>
 
-  <div class="<%= css_class %>">
-    <div class="mr-3">
-      <% if key.to_sym == :notice %>
-        <span class="material-icons text-blue-500">info</span>
-      <% elsif key.to_sym == :alert %>
-        <span class="material-icons text-red-500">error</span>
-      <% else %>
-        <span class="material-icons text-gray-500">notifications</span>
-      <% end %>
-    </div>
-    <div><%= value %></div>
-  </div>
-<% end %>
+      <div class="<%= css_class %>">
+        <div class="mr-3">
+          <% if key.to_sym == :notice %>
+            <span class="material-icons text-blue-500">info</span>
+          <% elsif key.to_sym == :alert %>
+            <span class="material-icons text-red-500">error</span>
+          <% else %>
+            <span class="material-icons text-gray-500">notifications</span>
+          <% end %>
+        </div>
+        <div><%= value %></div>
+      </div>
+    <% end %>
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
   get "home/index"
   root "home#index"
   resources :reviews do
-    resources :comments, only: [ :create, :destroy ]
+    resources :comments, only: [ :create, :destroy, :edit, :update ]
     resources :likes, only: [ :create, :destroy ]
   end
 


### PR DESCRIPTION
## 変更内容

- コメントの作成と削除機能を非同期で実装し、コメント表示のスタイルを改善 [詳細](https://github.com/taka292/minire/commit/ccbc1072605808e5966c76a96d3ee433cc24865f)
- コメント投稿時のフラッシュメッセージを追加し、コメントフォームのリセット機能を実装 [詳細](https://github.com/taka292/minire/commit/02cb313ee75d6eff7991776d44aa13319febf444)
- コメント削除時にフラッシュメッセージを追加し、Turbo Streamでのレスポンスを実装 [詳細](https://github.com/taka292/minire/commit/d2e349e1bb879748d512d79b13c9872ca44e5c7d)
- コメントの編集機能を追加し、フラッシュメッセージの表示を改善 [詳細](https://github.com/taka292/minire/commit/bddce184a7a0db67ab69fbe7d919fc8916d66563)
- フラッシュメッセージの表示を改善 [詳細](https://github.com/taka292/minire/commit/5247a25b4b873b95be6c9d3bcc72ab698c6ac3b2)
- コメント数の表示を更新し、コメント作成・削除時にリアルタイムで反映されるように改善 [詳細](https://github.com/taka292/minire/commit/a98d0e51485ae046f3791b689ca9a4e8fe910b51)
- コメントフォームのスタイルを改善し、ユーザーがログインしていない場合のメッセージを追加。コメントの内容を改行で表示するように変更し、編集・削除ボタンの配置を整理 [詳細](https://github.com/taka292/minire/commit/762f9b0fd016f07f51289839539e7950d283dc73)

## 目的

ユーザーがページをリロードせずにコメントを操作できるようにし、よりスムーズな体験を提供するため

詳細は各コミットリンクを参照。