### PR TITLE
Google Analyticsのgtag.jsタグを追加

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,16 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
+    <!-- Google Analytics (gtag.js) のタグ -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-ND1MZMEC14"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-ND1MZMEC14');
+    </script>
+
     <%= yield :head %>
 
     <!-- favicon(スマホ・PC・) -->


### PR DESCRIPTION
## 概要

Google Analyticsのgtag.jsタグを追加

## 変更内容

- Google Analyticsのgtag.jsタグを追加し、サイトのトラフィックを追跡可能にした

## 目的

サイト訪問者のデータを収集し、分析するため

詳細な変更内容やコミット履歴は[こちら](https://github.com/taka292/minire/commit/1ea698db28c9242165e543b7ffd265e553035e56)を参照。