### PR TITLE
レビュー関連のUI/UX改善

### DIFF
--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -84,9 +84,7 @@ end
 
   def edit
       @review = current_user.reviews.find(params[:id])
-      # 登録している手放せるものを差し引いた、空のフォームを追加
-      remaining_slots = [ 3 - @review.releasable_items.size, 0 ].max
-      remaining_slots.times { @review.releasable_items.build }
+      set_releasable_items
   end
 
   def update
@@ -127,6 +125,7 @@ end
       end
     end
   unless result
+    set_releasable_items
     render :edit, status: :unprocessable_entity
   end
 end
@@ -140,7 +139,7 @@ end
   end
 
   private
-  # accepts_nested_attributes_forで削除するものを_destroyを追加
+  # accepts_nested_attributes_forで削除するものを_destroyで追加
   def review_params
     params.require(:review).permit(:title, :content, :category_id, images: [], releasable_items_attributes: [ :id, :name, :_destroy ])
   end
@@ -150,5 +149,11 @@ end
     unless @review
       redirect_to reviews_path, alert: "他のユーザーのレビューは編集・削除できません。"
     end
+  end
+
+  # 手放せるものフォームで、すでに登録されている数を確認し、足りない分だけフォームを追加
+  def set_releasable_items
+    remaining_slots = [ 3 - @review.releasable_items.size, 0 ].max
+    remaining_slots.times { @review.releasable_items.build }
   end
 end

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -13,7 +13,9 @@
         <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
           <div class="form-control mb-4">
             <label class="label">
-              <span class="label-text text-base font-medium">名前</span>
+              <span class="label-text text-base font-medium">
+                名前 <span class="text-red-500">*</span>
+              </span>
             </label>
             <%= f.text_field :name, autofocus: true, placeholder: "ユーザー名を入力してください", class: "input input-bordered w-full h-14 text-base placeholder:text-sm #{error_class(resource, :name)}" %>
             <% if resource.errors[:name].present? %>
@@ -22,7 +24,9 @@
           </div>
           <div class="form-control mb-4">
             <label class="label">
-              <span class="label-text text-base font-medium">メールアドレス</span>
+              <span class="label-text text-base font-medium">
+                メールアドレス <span class="text-red-500">*</span>
+              </span>
             </label>
             <%= f.email_field :email, placeholder: "メールアドレスを入力してください", class: "input input-bordered w-full h-14 text-base placeholder:text-sm #{error_class(resource, :name)}" %>
             <% if resource.errors[:email].present? %>
@@ -31,7 +35,9 @@
           </div>
           <div class="form-control mb-4">
             <label class="label">
-              <span class="label-text text-base font-medium">パスワード</span>
+              <span class="label-text text-base font-medium">
+                パスワード <span class="text-red-500">*</span>
+              </span>
             </label>
             <%= f.password_field :password, autocomplete: "new-password", placeholder: "パスワードを入力してください", class: "input input-bordered w-full h-14 text-base placeholder:text-sm #{error_class(resource, :password)}" %>
             <% if resource.errors[:password].present? %>
@@ -40,7 +46,9 @@
           </div>
           <div class="form-control mb-4">
             <label class="label">
-              <span class="label-text text-base font-medium">パスワード（確認）</span>
+              <span class="label-text text-base font-medium">
+                パスワード（確認） <span class="text-red-500">*</span>
+              </span>
             </label>
             <%= f.password_field :password_confirmation, autocomplete: "new-password", placeholder: "パスワードを再入力してください", class: "input input-bordered w-full h-14 text-base placeholder:text-sm #{error_class(resource, :password_confirmation)}" %>
             <% if resource.errors[:password_confirmation].present? %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -13,6 +13,12 @@
     シンプルな選択を、あなたの毎日に。
   </p>
 
+  <!-- CTAボタン -->
+  <div class="mt-12 flex flex-col md:flex-row space-y-4 md:space-y-0 md:space-x-6">
+    <%= link_to "レビューを見る", reviews_path, class: "inline-flex items-center justify-center w-full md:w-auto bg-customBlue text-white px-8 py-4 text-lg rounded-lg shadow-md hover:scale-105 transition-transform" %>
+    <%= link_to "新規登録", new_user_registration_path, class: "inline-flex items-center justify-center w-full md:w-auto bg-customBlue text-white px-8 py-4 text-lg rounded-lg shadow-md hover:scale-105 transition-transform" %>
+  </div>
+
   <!-- 使い方セクション -->
   <div class="mt-12 space-y-16 max-w-4xl text-left">
     <h2 class="text-3xl font-semibold text-center border-b-4 border-gray-300 pb-4">MiniReの使い方</h2>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -13,7 +13,9 @@
           <!-- ユーザー名 -->
           <div class="form-control mb-4">
             <label class="label">
-              <span class="label-text text-base font-medium">ユーザー名</span>
+              <span class="label-text text-base font-medium">
+                ユーザー名 <span class="text-red-500">*</span>
+              </span>
             </label>
             <%= f.text_field :name, placeholder: "ユーザー名を入力してください", 
                              class: "input input-bordered w-full h-14 text-base placeholder:text-sm #{error_class(@user, :name)}" %>

--- a/app/views/reviews/_form.html.erb
+++ b/app/views/reviews/_form.html.erb
@@ -1,5 +1,7 @@
 <div class="form-control mb-6 relative" data-controller="autocomplete" data-autocomplete-url-value="<%= items_path %>"  >
-  <%= form.label :item_name, "商品名", class: "block text-lg font-medium text-gray-700" %>
+  <%= form.label :item_name, class: "block text-lg font-medium text-gray-700" do %>
+    商品名 <span class="text-red-500">*</span>
+  <% end %>
   <%= text_field_tag :item_name, @review.item&.name,
       placeholder: "商品名を入力してください", 
       class: "input input-bordered w-full h-12 text-lg placeholder:text-sm #{error_class(@review, :item_name)}", 
@@ -15,7 +17,9 @@
 </div>
 
 <div class="form-control mb-6">
-  <%= form.label :category_id, "カテゴリ", class: "block text-lg font-medium text-gray-700" %>
+  <%= form.label :category_id, class: "block text-lg font-medium text-gray-700" do  %>
+    カテゴリ <span class="text-red-500">*</span>
+  <% end %>
   <%= form.collection_select :category_id, Category.all, :id, :name,
         { prompt: "カテゴリを選択してください" },
         { class: "input input-bordered w-full h-12 text-lg placeholder:text-sm appearance-none pr-10 #{error_class(@review, :category)}" } %>
@@ -25,7 +29,9 @@
 </div>
 
 <div class="form-control mb-6">
-  <%= form.label :title, "タイトル", class: "block text-lg font-medium text-gray-700" %>
+  <%= form.label :title, class: "block text-lg font-medium text-gray-700" do  %>
+    タイトル <span class="text-red-500">*</span>
+  <% end %>
   <%= form.text_field :title, class: "input input-bordered w-full h-12 text-lg placeholder:text-sm #{error_class(@review, :title)}", placeholder: "レビュータイトルを入力してください" %>
   <% if form.object.errors[:title].any? %>
     <p class="text-red-500 text-sm mt-1"><%= form.object.errors[:title].first %></p>
@@ -33,7 +39,9 @@
 </div>
 
 <div class="form-control mb-6">
-  <%= form.label :content, "内容", class: "block text-lg font-medium text-gray-700" %>
+  <%= form.label :content, class: "block text-lg font-medium text-gray-700" do  %>
+    内容 <span class="text-red-500">*</span>
+  <% end %>
   <%= form.text_area :content, rows: 8, class: "textarea textarea-bordered w-full text-lg placeholder:text-sm #{error_class(@review, :content)}", placeholder: "レビュー内容を入力してください" %>
   <% if form.object.errors[:content].any? %>
     <p class="text-red-500 text-sm mt-1 "><%= form.object.errors[:content].first %></p>


### PR DESCRIPTION
## 概要

ホームページ上部にレビュー閲覧と新規登録ボタンを追加し、フォームの必須項目を表示するためのアスタリスクを追加しました。また、手放せるものフォームで商品名入力失敗時に空のフォームが消えてしまう事象を対処しました。

## 変更内容

1. **ホームページ上部にレビュー閲覧と新規登録ボタンを追加** ([コミット](https://github.com/taka292/minire/commit/d83b1b6b89a4a9b1b2ec5c792b74a994d2c3e642))
    - ホームページ上部にレビュー閲覧と新規登録ボタンを追加しました。
2. **フォームの必須項目を表示するために、ラベルにアスタリスクを追加** ([コミット](https://github.com/taka292/minire/commit/39e239c09bfb2ff33d40d501970ae3ffcd0e5cf6))
    - フォームの必須項目を表示するために、ラベルにアスタリスクを追加しました。
3. **手放せるものフォームで、商品名入力失敗時に空のフォームが消えてしまう事象を対処** ([コミット](https://github.com/taka292/minire/commit/41e59867e1a0f44fd1cbe79d4c9d3f6789956690))
    - 手放せるものフォームで商品名入力失敗時に空のフォームが消えてしまう事象を対処しました。

## 目的

- ユーザーがホームページ上部から簡単にレビューを閲覧・新規登録できるようにするため
- フォームの必須項目を明確にし、ユーザーの入力ミスを減らすため
- 手放せるものフォームの使用時に発生する入力失敗時の不具合を修正し、ユーザー体験を向上させるため