### PR TITLE
レビューカードにコメント数の取得方法を修正し、レビューの取得時にコメントを含めるように変更

### DIFF
--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -54,7 +54,7 @@ end
     if params[:sort] == "most_liked"
       @reviews = Review.with_likes_count
     else
-      @reviews = Review.includes(:user, :item, images_attachments: :blob)
+      @reviews = Review.includes(:user, :item, :comments, images_attachments: :blob)
     end
 
     @categories = Category.all

--- a/app/views/shared/_review_card.html.erb
+++ b/app/views/shared/_review_card.html.erb
@@ -45,7 +45,7 @@
     <!-- コメント -->
     <%= link_to "#{review_path(review)}#comments", class: "flex items-center space-x-1 text-gray-500 hover:text-gray-700 transition", title:"コメント" do %>
       <span class="material-icons text-2xl">chat_bubble_outline</span>
-      <span class="text-lg"><%= review.comments.count %></span>
+      <span class="text-lg"><%= review.comments.size %></span>
     <% end %>
   </div>
   <!-- 商品情報 -->


### PR DESCRIPTION
## 概要

レビューカードのUIを改善し、N + 1問題を回避するためにコメント数の取得方法を修正しました。

## 変更内容

1. **レビューカードにコメント数の取得方法を修正し、レビューの取得時にコメントを含めるように変更** ([コミット](https://github.com/taka292/minire/commit/77abe43204516a759bbd3ec9ea83d8cc628137c3))
    - N + 1問題を回避するために、レビューの取得時にコメントを含めるように変更しました。

## 目的

- N + 1問題を回避し、パフォーマンスを向上させるため