### PR TITLE
Amazon APIクライアントの環境変数名の変更とアイテム一覧に画像表示機能

### DIFF
--- a/app/services/amazon_api_client.rb
+++ b/app/services/amazon_api_client.rb
@@ -8,9 +8,9 @@ class AmazonApiClient
   attr_reader :access_key, :secret_key, :partner_tag, :region, :service, :host
 
   def initialize
-    @access_key = ENV["AWS_ACCESS_KEY_ID"]
-    @secret_key = ENV["AWS_SECRET_ACCESS_KEY"]
-    @partner_tag = ENV["PARTNER_TAG"]
+    @access_key = ENV["AMAZON_API_ACCESS_KEY"]
+    @secret_key = ENV["AMAZON_API_SECRET_KEY"]
+    @partner_tag = ENV["AMAZON_API_PARTNER_TAG"]
     @region = "us-west-2"
     @service = "ProductAdvertisingAPI"
     @host = "webservices.amazon.co.jp"

--- a/app/services/amazon_api_client.rb
+++ b/app/services/amazon_api_client.rb
@@ -50,7 +50,7 @@ class AmazonApiClient
   # ASINを指定して商品情報を取得
   def get_item_by_asin(asin)
     payload = {
-      "ItemIds": [asin],
+      "ItemIds": [ asin ],
       "Resources": [
         "ItemInfo.Title",
         "Images.Primary.Medium",

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -3,6 +3,11 @@
       role="option" 
       data-autocomplete-value="<%= item.id %>" 
       data-autocomplete-label="<%= item.name %>">
+
+    <% if item.images.attached? %>
+      <%= image_tag item.images.first.variant(resize_to_fill: [40, 40]), class: "w-10 h-10 object-cover rounded-md" %>
+    <% end %>
+
     <%= item.name %>
   </li>
 <% end %>


### PR DESCRIPTION
### 概要

Amazon APIクライアントの環境変数名の変更とアイテム一覧に画像表示機能を追加し、Lintチェックによる修正を行いました。

### 変更内容

1. **Amazon APIクライアントの環境変数名の変更とアイテム一覧に画像表示機能を追加** ([コミット](https://github.com/taka292/minire/commit/7731496321a2c35f685dfe214dd4b84fc1822117))
    - Amazon APIクライアントの環境変数名を変更しました。
    - アイテム一覧に画像表示機能を追加し、アイテムに関連する画像を表示するようにしました。
2. **Lintチェックによる修正** ([コミット](https://github.com/taka292/minire/commit/5ea98bbafe3f3da61cce731ec5b4e485d0f3549b))
    - Lintチェックによりコードの整形および修正を行いました。

### 目的

- 環境変数名の変更により、設定の一貫性を保つため。
- アイテム一覧に画像表示機能を追加することで、ユーザーエクスペリエンスを向上させるため。
- コードの品質を向上させ、保守性を高めるため。