### PR TITLE
Amazonの高画質画像取得化。メイン画像とバリエーション画像の保存を追加。

### DIFF
--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -39,40 +39,60 @@ end
 
 
   def fetch_amazon_info
-  item = Item.find(params[:id])
-  return redirect_to edit_admin_item_path(item), alert: "ASINが登録されていません" if item.asin.blank?
+    item = Item.find(params[:id])
+    return redirect_to edit_admin_item_path(item), alert: "ASINが登録されていません" if item.asin.blank?
 
-  client = AmazonApiClient.new
-  response = client.get_item_by_asin(item.asin)
-  amazon_item = response.dig("ItemsResult", "Items")&.first
+    client = AmazonApiClient.new
+    response = client.get_item_by_asin(item.asin)
+    amazon_item = response.dig("ItemsResult", "Items")&.first
 
-  if amazon_item.blank?
-    return redirect_to edit_admin_item_path(item), alert: "Amazonから情報を取得できませんでした"
-  end
-
-  # 画像URL取得
-  image_url = amazon_item.dig("Images", "Primary", "Medium", "URL")
-
-  # ActiveStorage に画像を保存
-  if image_url.present?
-    begin
-      downloaded_image = URI.open(image_url)
-      item.images.attach(io: downloaded_image, filename: File.basename(URI.parse(image_url).path))
-    rescue => e
-      Rails.logger.error "[AmazonAPI] 画像の保存に失敗: #{e.message}"
+    if amazon_item.blank?
+      return redirect_to edit_admin_item_path(item), alert: "Amazonから情報を取得できませんでした"
     end
+
+    # Primary画像（Large → Medium → Small の順で優先）
+    primary_image_url = amazon_item.dig("Images", "Primary", "Large", "URL") ||
+                        amazon_item.dig("Images", "Primary", "Medium", "URL") ||
+                        amazon_item.dig("Images", "Primary", "Small", "URL")
+
+    # Variants画像（複数ある可能性あり）
+    variant_images = amazon_item.dig("Images", "Variants") || []
+
+    variant_urls = variant_images.map do |variant|
+      variant.dig("Large", "URL") ||
+      variant.dig("Medium", "URL") ||
+      variant.dig("Small", "URL")
+    end.compact.uniq
+
+    # primary と重複していたら除外
+    variant_urls.reject! { |url| url == primary_image_url }
+
+    begin
+      # 1. メイン画像を最初に保存
+      if primary_image_url.present?
+        downloaded_image = URI.open(primary_image_url)
+        item.images.attach(io: downloaded_image, filename: File.basename(URI.parse(primary_image_url).path))
+      end
+
+      # 2. バリエーション画像を後から保存
+      variant_urls.each do |url|
+        downloaded_image = URI.open(url)
+        item.images.attach(io: downloaded_image, filename: File.basename(URI.parse(url).path))
+      end
+    rescue => e
+      Rails.logger.error "[AmazonAPI] 商品画像の保存に失敗: #{e.message}"
+    end
+
+    item.update(
+      manufacturer: amazon_item.dig("ItemInfo", "ByLineInfo", "Manufacturer", "DisplayValue"),
+      price:        amazon_item.dig("Offers", "Listings", 0, "Price", "Amount").to_i,
+      description:  (amazon_item.dig("ItemInfo", "Features", "DisplayValues") || []).join("\n"),
+      amazon_url:   amazon_item["DetailPageURL"],
+      last_updated_at: Time.current
+    )
+
+    redirect_to edit_admin_item_path(item), notice: "Amazon情報を更新しました"
   end
-
-  item.update(
-    manufacturer: amazon_item.dig("ItemInfo", "ByLineInfo", "Manufacturer", "DisplayValue"),
-    price:        amazon_item.dig("Offers", "Listings", 0, "Price", "Amount").to_i,
-    description:  (amazon_item.dig("ItemInfo", "Features", "DisplayValues") || []).join("\n"),
-    amazon_url:   amazon_item["DetailPageURL"],
-    last_updated_at: Time.current
-  )
-
-  redirect_to edit_admin_item_path(item), notice: "Amazon情報を更新しました"
-end
 
   private
 

--- a/app/controllers/amazon_controller.rb
+++ b/app/controllers/amazon_controller.rb
@@ -15,7 +15,7 @@ class AmazonController < ApplicationController
     @items = items.filter_map do |item|
       title = item.dig("ItemInfo", "Title", "DisplayValue")
       asin  = item["ASIN"]
-      image_url = item.dig("Images", "Primary", "Medium", "URL")
+      image_url = item.dig("Images", "Primary", "Large", "URL")
 
       # タイトルかASINが空なら次の商品へ
       next if title.blank? || asin.blank?

--- a/app/services/amazon_api_client.rb
+++ b/app/services/amazon_api_client.rb
@@ -25,7 +25,7 @@ class AmazonApiClient
       "Marketplace": "www.amazon.co.jp",
       "Resources": [
         "ItemInfo.Title",
-        "Images.Primary.Medium",
+        "Images.Primary.Large",
         "ItemInfo.ByLineInfo",
         "Offers.Listings.Price"
       ]
@@ -53,7 +53,8 @@ class AmazonApiClient
       "ItemIds": [ asin ],
       "Resources": [
         "ItemInfo.Title",
-        "Images.Primary.Medium",
+        "Images.Primary.Large",
+        "Images.Variants.Large",
         "ItemInfo.ByLineInfo",
         "ItemInfo.Features",
         "Offers.Listings.Price"


### PR DESCRIPTION
### 概要

Amazonの高画質画像取得機能の追加と、メイン画像およびバリエーション画像の保存機能を実装しました。

### 変更内容

1. **Amazon APIクライアントの環境変数名の変更とアイテム一覧に画像表示機能を追加** ([コミット](https://github.com/taka292/minire/commit/7731496321a2c35f685dfe214dd4b84fc1822117))
    - Amazon APIクライアントの環境変数名を変更しました。
    - アイテム一覧に画像表示機能を追加し、アイテムに関連する画像を表示するようにしました。
2. **Lintチェックによる修正** ([コミット](https://github.com/taka292/minire/commit/5ea98bbafe3f3da61cce731ec5b4e485d0f3549b))
    - Lintチェックによりコードの整形および修正を行いました。
3. **Amazonの高画質画像取得機能の追加** ([コミット](https://github.com/taka292/minire/commit/7801777cc1f4df7d4f8465cb7d348e0fe2e5552b))
    - Amazonの高画質画像を取得する機能を追加しました。
    - メイン画像およびバリエーション画像の保存機能を実装しました。

### 目的

- 環境変数名の変更により、設定の一貫性を保つため。
- アイテム一覧に画像表示機能を追加することで、ユーザーエクスペリエンスを向上させるため。
- コードの品質を向上させ、保守性を高めるため。
- 高画質画像の取得と保存機能を追加することで、商品の視覚的な情報を豊かにするため。