### PR TITLE
Amazon情報の表示

### DIFF
--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,20 +1,19 @@
 <% content_for :title, "#{@item.name} | MiniRe (ミニレ)" %>
 <% content_for :meta_description, "#{@item.name}の詳細ページです。商品情報と関連レビューを紹介します。#{@item.amazon_url.present? ? 'Amazonでの購入リンクも掲載しています。' : ''}" %>
+<% breadcrumb :item, @item %>
 
 <div class="bg-gray-100 min-h-screen py-8 px-4">
   <div class="max-w-6xl mx-auto bg-white px-6 sm:px-8 py-6 sm:py-8 shadow-md rounded-md space-y-8">
     <!-- 商品詳細セクション -->
     <div class="flex flex-col md:flex-row gap-8 sm:gap-12 items-start">
-    <%
-=begin
-    %>
+
       <!-- 左側: 商品画像 (横スクロール) -->
       <div class="w-full md:w-1/2">
         <div class="flex space-x-4 p-2  overflow-x-auto">
           <% if @item.images.attached? %>
             <% @item.images.each do |image| %>
               <img src="<%= url_for(image) %>" alt="<%= @item.name %>" 
-                   class="w-[300px] h-[250px] object-cover rounded-md shadow-md flex-shrink-0">
+                   class="object-cover rounded-md shadow-md flex-shrink-0">
             <% end %>
           <% else %>
 
@@ -27,25 +26,36 @@
           <% end %>
         </div>
       </div>
-    <%
-=end
-    %>
 
       <!-- 右側: 商品情報 -->
       <div class="flex flex-col w-full md:w-1/2 space-y-4 sm:space-y-6 px-4 sm:px-8">
-        <h1 class="text-2xl font-bold text-gray-800"><%= @item.name %></h1>
-        <p class="text-gray-600 text-base sm:text-lg">販売元: <%= @item.manufacturer || '情報がありません' %></p>
-        <p class="text-gray-600 text-base sm:text-lg">商品説明: <%= @item.description.present? ? safe_join(@item.description.split("\n"), tag(:br)) : '情報がありません' %></p>
-        <!--
-        <p class="text-gray-600 text-base sm:text-lg">価格: <%= @item.price.present? ? "¥#{number_to_currency(@item.price, unit: '', delimiter: ',')}" : '情報がありません' %></p>
-        -->
+        <div class="space-y-4">
+          <div class="bg-gray-50 border-l-4 border-blue-300 px-4 py-2 rounded">
+            <p class="text-sm text-gray-500 font-semibold">販売元</p>
+            <p class="text-base text-gray-800"><%= @item.manufacturer || '情報がありません' %></p>
+          </div>
 
-        <% if @item.amazon_url.present? %>
-          <%= link_to "Amazon", @item.amazon_url, 
-                      class: "btn bg-customBlue text-white border-0 hover:bg-blue-600 py-3 text-lg rounded-md text-center shadow-md w-full", target: :_blank %>
-        <% else %>
-          <p class="text-sm text-red-500 mt-4">Amazonのリンク情報は未登録です</p>
-        <% end %>
+          <div class="bg-gray-50 border-l-4 border-blue-300 px-4 py-2 rounded">
+            <p class="text-sm text-gray-500 font-semibold">商品説明</p>
+            <p class="text-base text-gray-800 leading-relaxed">
+              <%= @item.description.present? ? safe_join(@item.description.split("\n"), tag(:br)) : '情報がありません' %>
+            </p>
+          </div>
+
+          <% if @item.price.present? %>
+            <div class="bg-gray-50 border-l-4 border-blue-300 px-4 py-2 rounded">
+              <p class="text-sm text-gray-500 font-semibold">価格</p>
+              <p class="text-lg font-bold text-gray-900"><%= @item.price.present? ? "¥#{number_to_currency(@item.price, unit: '', delimiter: ',')}" : '情報がありません' %></p>
+            </div>
+          <% end %>
+
+          <% if @item.amazon_url.present? %>
+            <%= link_to "Amazon", @item.amazon_url, 
+                        class: "btn bg-customBlue text-white border-0 hover:bg-blue-600 py-3 text-lg rounded-md text-center shadow-md w-full", target: :_blank %>
+          <% else %>
+            <p class="text-sm text-red-500 mt-4">Amazonのリンク情報は未登録です</p>
+          <% end %>
+        </div>
       </div>
     </div>
   </div>

--- a/app/views/shared/_review_card.html.erb
+++ b/app/views/shared/_review_card.html.erb
@@ -54,16 +54,11 @@
 <% if review.item.present? %>
   <div class="flex items-center">
     <%= link_to item_path(review.item), class: "flex items-center w-full p-2 rounded-md hover:bg-gray-100 cursor-pointer transition duration-200" do %>
-      <!-- 商品画像（現在コメントアウト） -->
-      <!--
       <% if review.item.images.attached? %>
         <%= image_tag review.item.resized_images.first,
                       alt: "商品画像",
                       class: "w-16 h-16 object-cover rounded-md" %>
-      <% else %>
-        <%= image_tag "logo.png", alt: "MiniRe", class: "w-16 h-16 object-cover rounded-md" %>
       <% end %>
-      -->
       <div class="ml-4 flex-1">
         <% if review.item.manufacturer.present? %>
           <p class="text-sm text-gray-500"><%= review.item.manufacturer %></p>

--- a/app/views/shared/_review_card.html.erb
+++ b/app/views/shared/_review_card.html.erb
@@ -48,33 +48,31 @@
       <span class="text-lg"><%= review.comments.size %></span>
     <% end %>
   </div>
+  
   <!-- 商品情報 -->
-
-
-<% if review.item.present? %>
-  <div class="flex items-center">
-    <%= link_to item_path(review.item), class: "flex items-center w-full p-2 rounded-md hover:bg-gray-100 cursor-pointer transition duration-200" do %>
-      <% if review.item.images.attached? %>
-        <%= image_tag review.item.resized_images.first,
-                      alt: "商品画像",
-                      class: "w-16 h-16 object-cover rounded-md" %>
+  <% if review.item.present? %>
+    <div class="flex items-center">
+      <%= link_to item_path(review.item), class: "flex items-center w-full p-2 rounded-md hover:bg-gray-100 cursor-pointer transition duration-200" do %>
+        <% if review.item.images.attached? %>
+          <%= image_tag review.item.resized_images.first,
+                        alt: "商品画像",
+                        class: "w-16 h-16 object-cover rounded-md" %>
+        <% end %>
+        <div class="ml-4 flex-1">
+          <% if review.item.manufacturer.present? %>
+            <p class="text-sm text-gray-500"><%= review.item.manufacturer %></p>
+          <% end %>
+          <!--amazonの商品画像が使えないため、一時的に下記で詳細ページへ遷移を示す-->
+          <% if review.item.name.present? %>
+            <p class="text-md text-gray-800 font-medium underline"><%= "#{review.item.name}の詳細" %></p>
+          <% end %>
+        </div>
       <% end %>
-      <div class="ml-4 flex-1">
-        <% if review.item.manufacturer.present? %>
-          <p class="text-sm text-gray-500"><%= review.item.manufacturer %></p>
-        <% end %>
-        <!--amazonの商品画像が使えないため、一時的に下記で詳細ページへ遷移を示す-->
-        <% if review.item.name.present? %>
-          <p class="text-md text-gray-800 font-medium underline"><%= "#{review.item.name}の詳細" %></p>
-        <% end %>
-      </div>
-    <% end %>
-  </div>
-<% else %>
-  <div class="flex items-center text-gray-500">
-    <p>商品情報がありません</p>
-  </div>
-<% end %>
-
+    </div>
+  <% else %>
+    <div class="flex items-center text-gray-500">
+      <p>商品情報がありません</p>
+    </div>
+  <% end %>
 
 </div>

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -47,7 +47,7 @@ end
 
 crumb :item do |item|
   link item.name, item_path(item)
-  parent :items
+  parent :reviews
 end
 
 crumb :profile do |user|


### PR DESCRIPTION
### 概要

商品詳細ページのレイアウト改善と、レビューカードの表示機能の追加および修正を行いました。

### 変更内容

1. **商品詳細ページのレイアウト改善** ([コミット](https://github.com/taka292/minire/commit/521e46b622cb5f769f86a0b3d812cfa9c9f33fe5))
    - 商品詳細ページのレイアウトを改善し、価格、販売元、商品説明を強調表示しました。
    - パンクズリストの親要素を「レビュー」に変更しました。
2. **レビューカードから商品画像の表示部分を再表示** ([コミット](https://github.com/taka292/minire/commit/7989f9988f0d8261729c345362cd2a10daa04259))
    - レビューカードから商品画像の表示部分を再表示しました。
3. **レビューカードの商品の表示部分のインデント修正** ([コミット](https://github.com/taka292/minire/commit/c8f7ae05cb2f0eef5efafa9d289cfc606423d840))
    - レビューカードの商品の表示部分のインデントを修正しました。

### 目的

- 商品詳細ページの視認性とユーザーエクスペリエンスを向上させるため。
- レビューカードにおける商品の視覚的情報を強化し、ユーザーが商品の詳細を確認しやすくするため。
- コードの可読性と整形を改善し、保守性を高めるため。