### PR TITLE
検索メソッドでの結合を左外部結合に変更し、手放せるものがない場合でも正常に検索可能に

### DIFF
--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -96,7 +96,7 @@ class Review < ApplicationRecord
   def self.search(query)
     return all if query.blank?
 
-    joins(:item, :category, :releasable_items).where(
+    left_outer_joins(:item, :category, :releasable_items).where(
       "items.name ILIKE :query OR reviews.title ILIKE :query OR reviews.content ILIKE :query ",
       query: "%#{query}%"
     ).distinct


### PR DESCRIPTION
### 概要

検索メソッドの結合方法を左外部結合に変更し、手放せるものがない場合でも正常に検索ができるように修正しました。

### 変更内容

1. **検索メソッドの結合方法を左外部結合に変更** ([コミット](https://github.com/taka292/minire/commit/5ce37343abc1683717166dacd02d97303555f1d8))
    - 検索メソッドでの結合を `joins` から `left_outer_joins` に変更しました。
    - 手放せるものがない場合でも正常に検索結果が表示されるように修正しました。

### 目的

- 検索機能の改善を通じて、ユーザーが手放せるものがない場合でも検索結果が表示されるようにするため。