### PR TITLE
Feature/143 enable system specs in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,10 +56,10 @@ jobs:
           - 4444:4444
         options: >-
           --shm-size=2g
-          --health-cmd="curl -s http://localhost:4444/wd/hub/status | grep -q '\"ready\":true'"
+          --health-cmd="curl -s http://localhost:4444/wd/hub/status | jq -e '.value.ready == true'"
           --health-interval=10s
-          --health-timeout=5s
-          --health-retries=5
+          --health-timeout=10s
+          --health-retries=10
 
     env:
       RAILS_ENV: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,20 +41,14 @@ jobs:
     runs-on: ubuntu-latest
 
     services:
-      postgres:
+      db:
         image: postgres
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
         ports:
           - 5432:5432
-        options: --health-cmd="pg_isready" --health-interval=10s --health-timeout=5s --health-retries=3
-
-      # redis:
-      #   image: redis
-      #   ports:
-      #     - 6379:6379
-      #   options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
+        options: --health-cmd="pg_isready" --health-interval=10s --health-timeout=5s --health-retries=5
 
       selenium:
         image: selenium/standalone-chrome
@@ -67,10 +61,12 @@ jobs:
           --health-timeout=5s
           --health-retries=5
 
-    steps:
-      - name: Install packages
-        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y google-chrome-stable curl libjemalloc2 libvips postgresql-client
+    env:
+      RAILS_ENV: test
+      DATABASE_URL: postgres://postgres:postgres@localhost:5432
+      SELENIUM_DRIVER_URL: http://selenium:4444/wd/hub
 
+    steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
@@ -80,20 +76,21 @@ jobs:
           ruby-version: .ruby-version
           bundler-cache: true
 
-      - name: Run tests
-        env:
-          RAILS_ENV: test
-          DATABASE_URL: postgres://postgres:postgres@localhost:5432
-          # REDIS_URL: redis://localhost:6379/0
+      - name: Install dependencies
+        run: bundle install
+
+      - name: Set up DB
         run: |
           bundle exec rails db:create
           bundle exec rails db:schema:load
-          bundle exec rspec
+
+      - name: Run tests
+        run: bundle exec rspec
 
       - name: Keep screenshots from failed system tests
         uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: screenshots
-          path: ${{ github.workspace }}/tmp/screenshots
+          path: tmp/screenshots
           if-no-files-found: ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,10 @@ jobs:
           RAILS_ENV: test
           DATABASE_URL: postgres://postgres:postgres@localhost:5432
           # REDIS_URL: redis://localhost:6379/0
-        run: bin/rails db:test:prepare test test:system
+        run: |
+          bundle exec rails db:create
+          bundle exec rails db:schema:load
+          bundle exec rspec
 
       - name: Keep screenshots from failed system tests
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,17 @@ jobs:
       #     - 6379:6379
       #   options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
 
+    selenium:
+      image: selenium/standalone-chrome
+      ports:
+        - 4444:4444
+      options: >-
+        --shm-size=2g
+        --health-cmd="curl -s http://localhost:4444/wd/hub/status | grep -q '\"ready\":true'"
+        --health-interval=10s
+        --health-timeout=5s
+        --health-retries=5
+
     steps:
       - name: Install packages
         run: sudo apt-get update && sudo apt-get install --no-install-recommends -y google-chrome-stable curl libjemalloc2 libvips postgresql-client

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,16 +56,16 @@ jobs:
       #     - 6379:6379
       #   options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
 
-    selenium:
-      image: selenium/standalone-chrome
-      ports:
-        - 4444:4444
-      options: >-
-        --shm-size=2g
-        --health-cmd="curl -s http://localhost:4444/wd/hub/status | grep -q '\"ready\":true'"
-        --health-interval=10s
-        --health-timeout=5s
-        --health-retries=5
+      selenium:
+        image: selenium/standalone-chrome
+        ports:
+          - 4444:4444
+        options: >-
+          --shm-size=2g
+          --health-cmd="curl -s http://localhost:4444/wd/hub/status | grep -q '\"ready\":true'"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
 
     steps:
       - name: Install packages

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -72,7 +72,7 @@ RSpec.configure do |config|
   config.before(:each, type: :system) do
     driven_by :remote_chrome
     Capybara.server_host = IPSocket.getaddress(Socket.gethostname)
-    Capybara.server_port = 4444
+    Capybara.server_port = 3001
     Capybara.app_host = "http://#{Capybara.server_host}:#{Capybara.server_port}"
     Capybara.ignore_hidden_elements = false
   end

--- a/spec/system/profile_spec.rb
+++ b/spec/system/profile_spec.rb
@@ -28,7 +28,8 @@ RSpec.describe "プロフィール機能", type: :system do
       attach_file "user[avatar]", Rails.root.join("spec/fixtures/test_avatar.jpg")
       click_button "更新する"
 
-      expect(page).to have_current_path(profile_path(user))
+      # 遷移エラーを防ぐために、wait: 5を指定
+      expect(page).to have_current_path(profile_path(user), wait: 5)
       expect(page).to have_selector("img[src*='test_avatar.jpg']")
     end
 


### PR DESCRIPTION
### 概要

CI設定を更新し、システムテストを実行するように設定し、プロフィール機能のテストにwaitオプションを追加して遷移エラーを防止しました。

### 変更内容

1. **CI設定の更新**:
    - `.github/workflows/ci.yml` ファイルを修正し、システムテストを実行するように設定しました。
    - データベースの作成とスキーマのロードを追加し、テストの実行を行うように変更しました。
2. **プロフィール機能のテスト修正**:
    - `spec/system/profile_spec.rb` ファイルにおいて、プロフィール機能のテストで遷移エラーを防止するためにwaitオプションを追加しました。

### 目的

- システムテストをCIで実行することで、機能の品質を保証するため。
- テストの安定性を向上させ、遷移エラーを防止するため。

詳細な変更内容やコミット履歴は以下のリンクを参照してください。