### PR TITLE
Feature/224 add admin access control

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -19,10 +19,19 @@
 
     <!-- 右側：アイコン -->
     <div class="flex gap-2 flex-shrink-0 h-16 items-center">
+      <!-- 管理者用のアイコン -->
+      <% if user_signed_in? && current_user.admin? %>
+        <%= link_to admin_items_path, class: "flex items-center justify-center", title: "管理画面" do %>
+          <span class="material-symbols-outlined text-gray-600 text-3xl">admin_panel_settings</span>
+        <% end %>
+      <% end %>
+
+      <!-- レビュー一覧 -->
       <%= link_to reviews_path, class: "flex items-center justify-center", title: "レビュー 一覧" do %>
         <span class="material-symbols-outlined text-gray-600 text-3xl">quick_reference_all</span>
       <% end %>
 
+      <!-- いいねしたレビュー -->
       <% if user_signed_in? %>
         <%= link_to likes_profile_path(current_user, anchor: "likes"), class: "flex items-center justify-center", title: "いいねしたレビュー" do %>
           <span class="material-icons text-gray-600 text-3xl">favorite_border</span>
@@ -36,7 +45,7 @@
             </span>
           <% end %>
         <% end %>
-
+        <!-- プロフィールアイコン -->
         <%= link_to profile_path(current_user), class: "flex items-center justify-center", title: "プロフィール" do %>
           <% if current_user.avatar.attached? %>
             <%= image_tag current_user.resized_avatar, class: "w-10 h-10 rounded-full object-cover", alt: "アバター画像" %>
@@ -45,6 +54,7 @@
           <% end %>
         <% end %>
       <% else %>
+        <!-- ログインアイコン -->
         <%= link_to new_user_session_path, class: "flex items-center justify-center", title: "ログイン" do %>
           <span class="material-icons text-gray-600 text-3xl">login</span>
         <% end %>
@@ -65,15 +75,21 @@
 
       <!-- 右側：アイコン -->
       <div class="flex gap-2 h-14 items-center">
+        <!-- 管理者用のアイコン -->
+        <% if user_signed_in? && current_user.admin? %>
+          <%= link_to admin_items_path, class: "flex items-center justify-center", title: "管理画面" do %>
+            <span class="material-symbols-outlined text-gray-600 text-3xl">admin_panel_settings</span>
+          <% end %>
+        <% end %>
+        <!-- レビュー一覧 -->
         <%= link_to reviews_path, class: "flex items-center justify-center", title: "レビュー 一覧" do %>
           <span class="material-symbols-outlined text-gray-600 text-3xl">quick_reference_all</span>
         <% end %>
-
         <% if user_signed_in? %>
+          <!-- いいねしたレビュー -->
           <%= link_to likes_profile_path(current_user, anchor: "likes"), class: "flex items-center justify-center", title: "いいねしたレビュー" do %>
             <span class="material-icons text-gray-600 text-3xl">favorite_border</span>
           <% end %>
-
           <!-- 通知アイコン -->
           <%= link_to notifications_path, class: "relative flex items-center justify-center", title: "通知" do %>
             <span class="material-symbols-outlined text-gray-600 text-3xl">notifications</span>
@@ -83,7 +99,7 @@
               </span>
             <% end %>
           <% end %>
-
+          <!-- プロフィールアイコン -->
           <%= link_to profile_path(current_user), class: "flex items-center justify-center", title: "プロフィール" do %>
             <% if current_user.avatar.attached? %>
               <%= image_tag current_user.resized_avatar, class: "w-10 h-10 rounded-full object-cover", alt: "アバター画像" %>
@@ -92,6 +108,7 @@
             <% end %>
           <% end %>
         <% else %>
+          <!-- ログインアイコン -->
           <%= link_to new_user_session_path, class: "flex items-center justify-center", title: "ログイン" do %>
             <span class="material-icons text-gray-600 text-3xl">login</span>
           <% end %>

--- a/spec/system/admin_access_spec.rb
+++ b/spec/system/admin_access_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe "管理者アクセス", type: :system do
+  let!(:admin_user) { create(:user, email: "admin@example.com", password: "password", admin: true) }
+  let!(:general_user) { create(:user, email: "user@example.com", password: "password") }
+
+  def log_in(email:, password:)
+    visit new_user_session_path
+    fill_in "user[email]", with: email
+    fill_in "user[password]", with: password
+    click_button "ログイン"
+  end
+
+  it "管理者ユーザーはヘッダーに管理画面リンクが表示される" do
+    log_in(email: admin_user.email, password: admin_user.password)
+    expect(page).to have_content("ログインに成功しました")
+
+    expect(page).to have_selector("a[title='管理画面']")
+  end
+
+  it "一般ユーザーには管理画面リンクが表示されない" do
+    log_in(email: general_user.email, password: general_user.password)
+    expect(page).to have_content("ログインに成功しました")
+
+    expect(page).not_to have_selector("a[title='管理画面']")
+  end
+
+  it "未ログイン状態では管理画面リンクは表示されない" do
+    visit root_path
+    expect(page).not_to have_selector("a[title='管理画面']")
+  end
+
+  it "管理者ユーザーは管理画面にアクセスできる" do
+    log_in(email: admin_user.email, password: admin_user.password)
+
+    visit admin_items_path
+    expect(page).to have_content("アイテム")
+  end
+
+  it "一般ユーザーが管理画面にアクセスするとリダイレクトされる" do
+    log_in(email: general_user.email, password: general_user.password)
+    expect(page).to have_content("ログインに成功しました")
+
+    visit admin_items_path
+    expect(current_path).to eq root_path
+    expect(page).to have_content("管理者権限が必要です")
+  end
+end

--- a/spec/system/profile_spec.rb
+++ b/spec/system/profile_spec.rb
@@ -28,7 +28,8 @@ RSpec.describe "プロフィール機能", type: :system do
       attach_file "user[avatar]", Rails.root.join("spec/fixtures/test_avatar.jpg")
       click_button "更新する"
 
-      expect(page).to have_current_path(profile_path(user))
+      # 遷移エラーを防ぐために、wait: 5を指定
+      expect(page).to have_current_path(profile_path(user), wait: 5)
       expect(page).to have_selector("img[src*='test_avatar.jpg']")
     end
 

--- a/spec/system/review_spec.rb
+++ b/spec/system/review_spec.rb
@@ -168,6 +168,8 @@ RSpec.describe "レビュー投稿機能", type: :system do
 
       click_button "更新する"
 
+      # 画像がアップロードされたことを確認
+      expect(page).to have_current_path(edit_review_path(review), wait: 5)
       expect(page).to have_content("レビューを更新しました！")
       visit edit_review_path(review)
 
@@ -180,6 +182,8 @@ RSpec.describe "レビュー投稿機能", type: :system do
 
       click_button "更新する"
 
+      # 画像が削除されたことを確認
+      expect(page).to have_current_path(review_path(review), wait: 5)
       expect(page).to have_content("レビューを更新しました！")
 
       # どちらか一方の画像が残っている（両方削除するなら2つともnot_to）


### PR DESCRIPTION
### 概要

管理者用リンクの追加とテストの実装と、システムテストの修正を行いました。

### 変更内容

1. **管理者用リンクの追加とテストの実装**:
    - ヘッダーに管理者用リンクを追加し、管理者ユーザーのみがアクセスできるようにしました。
    - 管理者アクセスに関するシステムテストを追加しました。
2. **プロフィール機能とレビュー投稿機能のテスト修正**:
    - プロフィール機能とレビュー投稿機能のテストにおいて、遷移エラーを防ぐためにwaitオプションを追加しました。

### 目的

- 管理者ユーザーが管理画面にアクセスできるようにするため。
- テストの安定性を向上させ、遷移エラーを防止するため。

詳細な変更内容やコミット履歴は以下のリンクを参照してください。