### PR TITLE
管理者商品編集ページにASINフィールドを追加

### DIFF
--- a/app/views/admin/items/edit.html.erb
+++ b/app/views/admin/items/edit.html.erb
@@ -22,6 +22,10 @@
       <%= f.text_field :amazon_url, class: "input input-bordered w-full h-12 text-lg" %>
     </div>
     <div class="mb-4">
+      <%= f.label :asin, "ASIN", class: "block text-sm font-medium text-gray-700" %>
+      <%= f.text_field :asin, class: "input input-bordered w-full h-12 text-lg" %>
+    </div>docker compose exec web bundle exec rubocop -a
+    <div class="mb-4">
       <%= f.label :description, "商品説明", class: "block text-sm font-medium text-gray-700" %>
       <%= f.text_area :description, class: "input input-bordered w-full h-32 text-lg" %>
     </div>


### PR DESCRIPTION
### 概要

以下の3つのコミットをまとめ、本番リリース前の修正対応を行いました。

### 変更内容

1. **管理者商品編集ページにASINフィールドを追加**:
    - 管理者商品編集ページにASINフィールドを追加し、商品情報の入力をより充実させました。

### 目的

- 商品情報の入力を充実させ、管理者がより詳細な情報を入力できるようにするため。