### PR TITLE
Brakemanを7.0.1にアップデート

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,7 +78,7 @@ group :development, :test do
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"
 
   # Static analysis for security vulnerabilities [https://brakemanscanner.org/]
-  gem "brakeman", "~> 7.0", require: false
+  gem "brakeman", "~> 7.0.1", require: false
 
   # Omakase Ruby styling [https://github.com/rails/rubocop-rails-omakase/]
   gem "rubocop-rails-omakase", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,7 +101,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.18.4)
       msgpack (~> 1.2)
-    brakeman (7.0.0)
+    brakeman (7.0.1)
       racc
     builder (3.3.0)
     bullet (8.0.0)
@@ -458,7 +458,7 @@ PLATFORMS
 DEPENDENCIES
   aws-sdk-s3
   bootsnap
-  brakeman (~> 7.0)
+  brakeman (~> 7.0.1)
   bullet
   capybara
   cssbundling-rails


### PR DESCRIPTION
CIチェックエラーのため、
Brakemanを7.0から7.0.1にアップデート