### PR TITLE
価格情報の表示をコメントアウトし、テストケースを更新

### DIFF
--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -42,7 +42,7 @@
             </p>
           </div>
 
-          <!-- 価格を乗せる場合、取得日時等も合わせて乗せる必要があるため、現状コメントアウト -->
+          <!-- 価格を乗せる場合、取得日時等も合わせて乗せる必要があり、APIでデータ取得できるまでコメントアウト
           <% if @item.price.present? %>
             <div class="bg-gray-50 border-l-4 border-blue-300 px-4 py-2 rounded">
               <p class="text-sm text-gray-500 font-semibold">価格</p>
@@ -54,6 +54,7 @@
               </small>
             </div>
           <% end %>
+           -->
 
           <% if @item.amazon_url.present? %>
             <%= link_to "Amazon", @item.amazon_url, 

--- a/spec/system/items_spec.rb
+++ b/spec/system/items_spec.rb
@@ -17,12 +17,12 @@ RSpec.describe "商品詳細ページ", type: :system do
         )
       end
 
-      it "商品情報と画像が表示される" do
+      it "商品情報と画像が表示される(価格情報非表示)" do
         visit item_path(item)
 
         expect(page).to have_content("ミニマル収納ボックス")
         expect(page).to have_content("ミニマル社")
-        expect(page).to have_content("¥3,500")
+        # expect(page).to have_content("¥3,500")
         expect(page).to have_content("シンプルな収納ボックスです。")
         expect(page).to have_link("Amazon", href: "https://www.amazon.co.jp/dp/B012345678")
         expect(page).to have_css("img[src*='test_item.jpg']")


### PR DESCRIPTION
### 概要

価格情報の表示をコメントアウトし、テストケースを更新しました。

### 変更内容

1. **価格表示のコメントアウト**:
    - 商品の価格情報を表示する部分をコメントアウトし、APIでデータを取得できるまで一時的に非表示にしました。
    - [コミット ce2167b47e9881ff78493bd1986bf5f8fe8a6fad](https://github.com/taka292/minire/commit/ce2167b47e9881ff78493bd1986bf5f8fe8a6fad)
2. **テストケースの更新**:
    - 価格情報を非表示にしたことに伴い、テストケースを更新しました。
    - [コミット ce2167b47e9881ff78493bd1986bf5f8fe8a6fad](https://github.com/taka292/minire/commit/ce2167b47e9881ff78493bd1986bf5f8fe8a6fad)

### 目的

- APIでデータを取得できるまで、価格情報の表示を一時的にコメントアウトするため。
- 価格情報の非表示に伴い、テストケースを更新し、テストの整合性を保つため。