### PR TITLE
コメント閲覧機能をログインユーザーのみに制限し、未ログイン時のメッセージを追加

### DIFF
--- a/app/views/reviews/show.html.erb
+++ b/app/views/reviews/show.html.erb
@@ -108,6 +108,8 @@
   </div>
 
   <div class="mt-8">
+    <!--ログイン時のみ、コメント閲覧可能-->
+    <% if user_signed_in? %>
     <h2 id = "comments_count" class="text-xl font-bold mb-6"><%= @review.comments.count %>件のコメント</h2>
 
     <div id="flash_message" class="mb-5">
@@ -119,7 +121,15 @@
     </div>
 
     <!--非同期でのコメントの表示-->
-    <div id="comments">
-      <%= render "comments/comments", comments: @comments %>
-    </div>
+      <div id="comments">
+        <%= render "comments/comments", comments: @comments %>
+      </div>
+    <% else %>
+      <div class="text-center mt-6 p-4 border rounded-md bg-gray-50 text-gray-700">
+        コメントを見るには
+        <%= link_to "ログイン", new_user_session_path, class: "text-blue-600 underline" %>
+        が必要です。
+      </div>
+    <% end %>
+  </div>
 </div>

--- a/spec/system/comment_spec.rb
+++ b/spec/system/comment_spec.rb
@@ -69,12 +69,24 @@ RSpec.describe "コメント機能", type: :system do
       expect(page).not_to have_selector("a", id: "button-delete-#{Comment.last.id}")
     end
 
-    it "ログアウト状態ではコメントフォームが表示されない" do
+    #     今後「未ログインでもコメント閲覧OK」にする可能性があるため、一旦コメントアウト。
+    #     投稿はログイン必須のままの場合は、このテストは必要。
+    #     it "ログアウト状態ではコメントフォームが表示されない" do
+    #       logout
+    #       visit review_path(review)
+    #
+    #       expect(page).not_to have_selector("form#new_comment")
+    #       expect(page).to have_content("ログインしてコメントする")
+    #     end
+
+    it "ログアウト状態ではコメント一覧が表示されない" do
+      review.comments.create!(content: "表示されないはずのコメント", user: user)
       logout
       visit review_path(review)
 
-      expect(page).not_to have_selector("form#new_comment")
-      expect(page).to have_content("ログインしてコメントする")
+      expect(page).not_to have_content("表示されないはずのコメント")
+      expect(page).not_to have_selector("#comments")
+      expect(page).to have_content("コメントを見るには")
     end
   end
 end


### PR DESCRIPTION
### 概要

コメント閲覧機能をログインユーザーのみに制限し、未ログイン時のメッセージを追加しました。

### 変更内容

1. **コメント閲覧機能の制限**:
    - コメントの閲覧をログインユーザーのみに制限し、未ログイン時にはログインを促すメッセージを表示するように変更しました。
    - [コミット 5f6610f66560d0e7040ab0678653fc92833f246c](https://github.com/taka292/minire/commit/5f6610f66560d0e7040ab0678653fc92833f246c)
2. **テストケースの更新**:
    - コメント閲覧機能の変更に伴い、未ログイン時のテストケースを追加および更新しました。
    - [コミット 5f6610f66560d0e7040ab0678653fc92833f246c](https://github.com/taka292/minire/commit/5f6610f66560d0e7040ab0678653fc92833f246c)

### 目的

- コメントの閲覧をログインユーザーのみに制限し、セキュリティおよびプライバシーを強化するため。
- 未ログインユーザーに対してログインを促すことで、ユーザー登録を促進するため。