### PR TITLE
amazon apiの再実装

### DIFF
--- a/app/views/admin/items/edit.html.erb
+++ b/app/views/admin/items/edit.html.erb
@@ -24,7 +24,7 @@
     <div class="mb-4">
       <%= f.label :asin, "ASIN", class: "block text-sm font-medium text-gray-700" %>
       <%= f.text_field :asin, class: "input input-bordered w-full h-12 text-lg" %>
-    </div>docker compose exec web bundle exec rubocop -a
+    </div>
     <div class="mb-4">
       <%= f.label :description, "商品説明", class: "block text-sm font-medium text-gray-700" %>
       <%= f.text_area :description, class: "input input-bordered w-full h-32 text-lg" %>

--- a/app/views/reviews/_form.html.erb
+++ b/app/views/reviews/_form.html.erb
@@ -1,5 +1,4 @@
 
-<!-- 検索方法の選択 (amazonAPIが現在使用できないため、コメントアウト)
 <div class="form-control mb-6" data-controller="search-toggle">
   <label class="block text-lg font-medium text-gray-700">商品名検索方法</label>
   <div class="flex gap-4 mt-2">
@@ -17,7 +16,6 @@
     ※検索しても商品が見つからない場合は、「MiniRe検索」を選び、商品名の入力をお願いします。
   </p>
 </div>
- -->
 
 <!-- 登録アイテムフォーム -->
 <div id="minire-form" class="form-control mb-6 relative" data-controller="autocomplete" data-autocomplete-url-value="<%= items_path %>"  >
@@ -35,10 +33,10 @@
   <% if form.object.errors[:item_name].any? %>
     <p class="text-red-500 text-sm mt-1"><%= form.object.errors[:item_name].first %></p>
   <% end %>
-  <ul class="list-group bg-white border border-gray-300 rounded-md shadow-md absolute top-full left-0 w-full md:text-sm max-w-max" data-autocomplete-target="results"></ul>
+  <ul class="list-group bg-white border border-gray-300 rounded-md shadow-md absolute top-full left-0 w-full md:text-sm max-w-max  z-50" data-autocomplete-target="results"></ul>
 </div>
 
-<!-- Amazon検索フォーム (amazonAPIが現在使用できないため、コメントアウト)
+<!-- Amazon検索フォーム -->
 <div id="amazon-form" class="form-control mb-6 relative hidden" data-controller="autocomplete" data-autocomplete-url-value="<%= amazon_index_path %>">
   <%= form.label :amazon_item_name, class: "block text-lg font-medium text-gray-700" do %>
     商品名 <span class="text-red-500">*</span>
@@ -58,11 +56,10 @@
     <p class="text-red-500 text-sm mt-1"><%= form.object.errors[:amazon_item_name].first %></p>
   <% end %>
 
-  <ul class="list-group bg-white border border-gray-300 rounded-md shadow-md absolute top-full left-0 w-full md:text-sm max-w-max"
+  <ul class="list-group bg-white border border-gray-300 rounded-md shadow-md absolute top-full left-0 w-full md:text-sm max-w-max z-50"
       data-autocomplete-target="results">
   </ul>
 </div>
- -->
 
 <div class="form-control mb-6">
   <%= form.label :category_id, class: "block text-lg font-medium text-gray-700" do  %>


### PR DESCRIPTION
### 概要

Amazon APIを利用したレビュー投稿機能を再度実装し、管理者編集画面のASINフィールドの不要なコードを削除しました。

### 変更内容

1. **管理者編集画面のASINフィールドの不要なコードを削除**:
    - 管理者編集画面のASINフィールドに含まれていた不要なコードを削除しました。
    - [コミット 5d9058b8d03835fbaf729ddd5c9fe34dfc2d1942](https://github.com/taka292/minire/commit/5d9058b8d03835fbaf729ddd5c9fe34dfc2d1942)
2. **Amazon APIを利用したレビュー投稿機能の再実装**:
    - Amazon APIを使用したレビュー投稿機能を再度実装しました。
    - POSTリクエストでAmazonのASINと商品名を入力し、レビューを投稿できるようにしました。
    - Amazon APIを利用した際に、ASINと商品名の両方が入力されていない場合はエラーメッセージを表示するようにしました。
    - 関連するテストケースを追加し、Amazon APIを利用したレビュー投稿と編集の動作を確認しました。
    - [コミット efb0a45e290f394d38fa9b99f41b874d130f73f1](https://github.com/taka292/minire/commit/efb0a45e290f394d38fa9b99f41b874d130f73f1)

### 目的

- 管理者画面のコードを整理し、不要なコードを削除してメンテナンス性を向上させるため。
- Amazon APIを利用することで、ユーザーがAmazonの商品情報を簡単にレビューに追加できるようにし、レビュー投稿の利便性を向上させるため。