### PR TITLE
レビュー詳細の商品名の2重表示を修正し、〜「の詳細」という文言を削除

### DIFF
--- a/app/views/reviews/show.html.erb
+++ b/app/views/reviews/show.html.erb
@@ -94,13 +94,9 @@
           <% if @review.item.manufacturer.present? %>
             <p class="text-sm text-gray-500"><%= @review.item.manufacturer %></p>
           <% end %>
-          <!-- 商品名 -->
-          <% if @review.item.name.present? %>
-            <p class="text-md text-gray-800 font-medium"><%= @review.item.name %></p>
-          <% end %>
           <!-- 商品の詳細リンク -->
           <% if @review.item.name.present? %>
-            <p class="text-md text-gray-800 font-medium underline"><%= "#{@review.item.name}の詳細" %></p>
+            <p class="text-md text-gray-800 font-medium underline"><%= @review.item.name %></p>
           <% end %>
         </div>
       <% end %>

--- a/app/views/shared/_review_card.html.erb
+++ b/app/views/shared/_review_card.html.erb
@@ -63,7 +63,7 @@
             <p class="text-sm text-gray-500"><%= review.item.manufacturer %></p>
           <% end %>
           <% if review.item.name.present? %>
-            <p class="text-md text-gray-800 font-medium underline"><%= "#{review.item.name}の詳細" %></p>
+            <p class="text-md text-gray-800 font-medium underline"><%= review.item.name %></p>
           <% end %>
         </div>
       <% end %>


### PR DESCRIPTION
### 概要

レビュー詳細の商品名の2重表示を修正し、〜「の詳細」という文言を削除しました。

### 変更内容

- レビュー詳細ページで商品名が2回表示されていた問題を修正しました。
- 商品名リンクの文言から「の詳細」を削除し、シンプルに商品名のみを表示するようにしました。
- [コミット b1382a7c8102dc622f76eef556df6db772ed9d6a](https://github.com/taka292/minire/commit/b1382a7c8102dc622f76eef556df6db772ed9d6a)

### 影響範囲

- レビュー詳細ページ
- レビュー一覧ページ

### 目的

- 商品名の表示をシンプルにし、ユーザーにとって分かりやすいUIを提供するため。