### PR TITLE
UIの修正

### DIFF
--- a/app/views/reviews/_form.html.erb
+++ b/app/views/reviews/_form.html.erb
@@ -4,7 +4,7 @@
   <div class="flex gap-4 mt-2">
     <label class="flex items-center gap-2">
       <%= radio_button_tag :search_method, "amazon", action_name == "new", data: { action: "search-toggle#toggle" } %>
-      Amazon検索
+      Amazon検索(6文字以上)
     </label>
     <label class="flex items-center gap-2">
       <%= radio_button_tag :search_method, "minire", action_name == "edit", data: { action: "search-toggle#toggle" } %>
@@ -24,7 +24,7 @@
   <% end %>
 
   <%= text_field_tag :amazon_item_name, nil,
-      placeholder: "Amazonの商品名を入力してください",
+      placeholder: "6文字以上のAmazonの商品名を入力してください",
       class: "input input-bordered w-full h-12 text-lg placeholder:text-sm #{error_class(@review, :amazon_item_name)}", 
       data: {
         autocomplete_target: "input",

--- a/spec/system/review_spec.rb
+++ b/spec/system/review_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "レビュー投稿機能", type: :system do
       fill_in "review[content]", with: "内容テスト"
       click_button "投稿する"
 
-      expect(page).to have_current_path(reviews_path)
+      expect(page).to have_current_path(reviews_path, wait: 5)
       expect(page).to have_content("レビューを投稿しました！")
       expect(page).to have_content("タイトルテスト")
     end
@@ -104,6 +104,7 @@ RSpec.describe "レビュー投稿機能", type: :system do
       click_button "投稿する"
 
       # 投稿されたことの確認
+      expect(page).to have_current_path(reviews_path, wait: 10)
       expect(page).to have_content("レビューを投稿しました！", wait: 5)
       expect(page).to have_css("img[src*='sample1.jpg']")
       expect(page).to have_css("img[src*='sample2.jpg']")
@@ -126,7 +127,7 @@ RSpec.describe "レビュー投稿機能", type: :system do
       click_button "投稿する"
 
       # 投稿されたことを確認
-      expect(page).to have_content("レビューを投稿しました！", wait: 5)
+      expect(page).to have_content("レビューを投稿しました！", wait: 10)
 
       item = Item.find_by(name: "画像コピーアイテム")
       expect(item).to be_present
@@ -195,7 +196,7 @@ RSpec.describe "レビュー投稿機能", type: :system do
       click_button "更新する"
 
       # 投稿されたことを確認
-      expect(page).to have_current_path(edit_review_path(review), wait: 5)
+      expect(page).to have_current_path(edit_review_path(review), wait: 20)
       expect(page).to have_content("レビューを更新しました！")
       visit edit_review_path(review)
 


### PR DESCRIPTION
### 概要

Amazon検索のラベルとプレースホルダーに「6文字以上」の説明を追加し、レビュー投稿機能のテストにおいてページ遷移の待機時間を延長しました。

### 変更内容

1. **Amazon検索のラベルとプレースホルダーの更新**:
    - Amazon検索ラベルに「(6文字以上)」を追加。
    - プレースホルダーに「6文字以上のAmazonの商品名を入力してください」を追加。
    - コミット: [2afbae734f282b6bee465587c8903d8cbd5649af](https://github.com/taka292/minire/commit/2afbae734f282b6bee465587c8903d8cbd5649af)
2. **レビュー投稿機能のテストでページ遷移の待機時間を延長**:
    - レビュー投稿機能のテストにおいて、ページ遷移の待機時間を延長。
    - コミット: [b16c863f5d09c048ab9a9d073d4361451a281479](https://github.com/taka292/minire/commit/b16c863f5d09c048ab9a9d073d4361451a281479)

### 目的

- ユーザーに対して、Amazon検索時に必要な文字数を明確に案内し、検索機能の利便性を向上させるため。
- テストにおいてページ遷移の待機時間を延長することで、テストの安定性を向上させるため。