### PR TITLE
シェアボタンのツイート内容を更新

### DIFF
--- a/app/views/shared/_x_share_button.html.erb
+++ b/app/views/shared/_x_share_button.html.erb
@@ -1,7 +1,8 @@
 <!-- X投稿内容(stripで行末の改行を削除) -->
 <% tweet_text = <<~EOF.strip
-  【レビュー紹介】
-  〜#{@review.title}〜
+  【MiniReレビュー紹介】
+
+  「#{@review.title}」
   #{truncate(@review.content, length: 50, omission: "…")}
 
   詳細のレビューはこちら↓


### PR DESCRIPTION
### **概要**

レビュー詳細ページのシェアボタンのツイート内容を更新し、レビュータイトルを強調するようにしました。

### **変更内容**

- シェアボタンのツイート内容を更新し、レビュータイトルを「MiniReレビュー紹介」として強調しました。
- コミット: [a92d2a1def6d437c81d04142118b79fcf27dce9a](https://github.com/taka292/minire/commit/a92d2a1def6d437c81d04142118b79fcf27dce9a)

### **目的**

- ユーザーがレビューをSNSでシェアする際、タイトルを強調することで視認性を向上させ、クリック率を高めるため。

詳細な変更内容やコミット履歴は上記のリンクを参照してください。