### PR TITLE
Amazonリンクボタンをレビュー詳細とレビューカードに追加し、レビュー詳細の編集・削除ボタンにテキストを追加

### DIFF
--- a/app/views/reviews/show.html.erb
+++ b/app/views/reviews/show.html.erb
@@ -72,18 +72,19 @@
       </div>
     <% end %>
 
+
     <!-- 編集・削除ボタン -->
     <% if current_user == @review.user %>
-      <div class="flex justify-end gap-4 mt-4">
+      <div class="flex items-center justify-end gap-4 mt-4">
         <%= link_to edit_review_path(@review), class: "flex items-center gap-1 hover:text-blue-600", title: "レビュー編集" do %>
-          <span class="material-symbols-outlined">edit_document</span>
+          <span class="material-symbols-outlined">edit_document</span> 編集
         <% end %>
 
         <%= link_to review_path(@review),
                     method: :delete,
                     data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" },
                     class: "flex items-center gap-1 hover:text-red-600", title: "レビュー削除" do %>
-          <span class="material-symbols-outlined">delete</span>
+          <span class="material-symbols-outlined">delete</span> 削除
         <% end %>
       </div>
     <% end %>
@@ -96,6 +97,13 @@
       <%= render "shared/x_share_button", review: @review %>
       <!-- いいねボタン -->
       <%= render "shared/review_like_section", review: @review %>
+
+      <!-- Amazonリンクボタン（アイコンのみ）-->
+      <% if @review.item&.amazon_url.present? %>
+        <%= link_to @review.item.amazon_url, target: :_blank, rel: "noopener", class: "flex items-center text-gray-500 hover:text-gray-700 transition", title: "Amazonで購入する" do %>
+          <span class="material-symbols-outlined text-2xl">shopping_cart</span>
+        <% end %>
+      <% end %>
     </div>
 
     <!-- 商品情報 -->

--- a/app/views/shared/_review_card.html.erb
+++ b/app/views/shared/_review_card.html.erb
@@ -47,8 +47,15 @@
       <span class="material-icons text-2xl">chat_bubble_outline</span>
       <span class="text-lg"><%= review.comments.size %></span>
     <% end %>
+
+    <!-- Amazonリンクボタン（アイコンのみ）-->
+    <% if review.item&.amazon_url.present? %>
+      <%= link_to review.item.amazon_url, target: :_blank, rel: "noopener", class: "flex items-center text-gray-500 hover:text-gray-700 transition", title: "Amazonで購入する" do %>
+        <span class="material-symbols-outlined text-2xl">shopping_cart</span>
+      <% end %>
+    <% end %>
   </div>
-  
+
   <!-- 商品情報 -->
   <% if review.item.present? %>
     <div class="flex items-center">

--- a/spec/system/review_spec.rb
+++ b/spec/system/review_spec.rb
@@ -350,6 +350,16 @@ RSpec.describe "レビュー投稿機能", type: :system do
       expect(link).to include(include_text)
       expect(link).to include("minire")
     end
+
+    it "レビュー一覧にAmazonリンクが表示される" do
+      visit reviews_path
+      expect(page).to have_link(href: item.amazon_url)
+    end
+
+    it "レビュー詳細にAmazonリンクが表示される" do
+      visit review_path(review)
+      expect(page).to have_link(href: item.amazon_url)
+    end
   end
 
   describe "Amazon検索を使ったレビュー投稿" do


### PR DESCRIPTION
### **概要**

このプルリクエストでは、Amazonリンクボタンをレビュー詳細ページおよびレビューカードに追加しました。また、レビュー詳細ページの編集・削除ボタンにテキストを追加し、操作性を向上させました。

---

### **主な変更内容**

1. **Amazonリンクボタンの追加**:
    - レビュー詳細ページとレビューカードにAmazonリンクボタンを追加。
    - ユーザーが関連商品をAmazonで簡単に確認・購入できるようにしました。
    - **対象ファイル**:
        - `app/views/reviews/show.html.erb`
        - `app/views/shared/_review_card.html.erb`
2. **編集・削除ボタンの改善**:
    - レビュー詳細ページの編集・削除ボタンにテキストを追加し、分かりやすさを向上。
    - **対象ファイル**: `app/views/reviews/show.html.erb`
3. **テストの追加**:
    - Amazonリンクがレビュー一覧および詳細ページに正しく表示されることを確認するテストを追加。
    - **対象ファイル**: `spec/system/review_spec.rb`

---

### **コミット**

- [b30a34c30b9071340d997e82a617d6ba712e511a](https://github.com/taka292/minire/commit/b30a34c30b9071340d997e82a617d6ba712e511a)

---

### **目的**

- レビューに関連する商品をAmazonで簡単に購入できる導線を提供し、利便性を向上。
- UIの改善により、ユーザーが操作しやすいインターフェースを実現。