### PR TITLE
レビュー作成時および更新時のアイテム関連付け処理をリファクタリングし、コントローラーからモデルに処理を移行

### DIFF
--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -10,21 +10,21 @@ class ReviewsController < ApplicationController
     @review = current_user.reviews.build(review_params)
 
     result = ActiveRecord::Base.transaction do
-      unless assign_item_to_review
+      unless @review.assign_item_by_params(params)
+        # item関連のエラーが付与されたのでここでリダイレクトしない
         raise ActiveRecord::Rollback
       end
 
-      if @review.save
-        attach_image_to_item_if_needed
-        redirect_to reviews_path, notice: "レビューを投稿しました！"
-      else
+      unless @review.save
         raise ActiveRecord::Rollback
       end
+
+      attach_image_to_item_if_needed
+      redirect_to reviews_path, notice: "レビューを投稿しました！"
     end
 
     render :new, status: :unprocessable_entity unless result
   end
-
 
   def show
     @review = Review.find(params[:id])
@@ -71,19 +71,14 @@ class ReviewsController < ApplicationController
 
   def update
     result = ActiveRecord::Base.transaction do
-      unless assign_item_to_review
-        raise ActiveRecord::Rollback
-      end
+      raise ActiveRecord::Rollback unless @review.assign_item_by_params(params)
 
       handle_image_removal
       @review.images.attach(params[:review][:images]) if params[:review][:images].present?
 
-      if @review.update(review_params.except(:images))
-        # attach_image_to_item_if_needed # 画像をitemに添付処理はリファクタリングとは別で対応
-        redirect_to @review, notice: "レビューを更新しました！"
-      else
-        raise ActiveRecord::Rollback
-      end
+      raise ActiveRecord::Rollback unless @review.update(review_params.except(:images))
+      # attach_image_to_item_if_needed # 画像をitemに添付処理はリファクタリングとは別で対応
+      redirect_to @review, notice: "レビューを更新しました！"
     end
 
     render :edit, status: :unprocessable_entity unless result
@@ -100,7 +95,7 @@ class ReviewsController < ApplicationController
   private
   # accepts_nested_attributes_forで削除するものを_destroyで追加
   def review_params
-    params.require(:review).permit(:title, :content, :category_id, images: [], releasable_items_attributes: [ :id, :name, :_destroy ])
+    params.require(:review).permit(:title, :content, :category_id,  images: [], releasable_items_attributes: [ :id, :name, :_destroy ])
   end
 
   def set_review
@@ -108,60 +103,6 @@ class ReviewsController < ApplicationController
     unless @review
       redirect_to reviews_path, alert: "他のユーザーのレビューは編集・削除できません。"
     end
-  end
-
-  # Amazon検索で取得したItemがまだ詳細情報を持っていない場合のみ、Amazon APIから取得して補完する
-  def fetch_amazon_info_if_needed(item)
-    if item.asin.present? && item.last_updated_at.blank?
-      imported_item = AmazonItemImporter.new(item.asin).import!
-      return imported_item if imported_item.present?
-    end
-    item
-  end
-
-  # 商品をレビューに関連付ける
-  def assign_item_to_review
-    # Amazonまたはサイト内検索に応じてItemを取得・登録し、レビューに関連付ける
-    case params[:search_method]
-    when "amazon"  # Amazon商品検索・登録(デフォルト)
-      asin = params[:asin]&.strip # Amazonの商品コード
-      item_name = params[:amazon_item_name]&.strip # Amazon商品名
-
-      if asin.blank? || item_name.blank?
-        @review.errors.add(:amazon_item_name, "Amazonの商品を選択してください")
-        return false
-      end
-
-      item = fetch_amazon_info_if_needed(Item.find_or_initialize_by(asin: asin))
-
-      if item.name.blank?
-        @review.errors.add(:amazon_item_name, "商品情報の取得に失敗しました。もう一度お試しください")
-        return false
-      end
-
-    when "minire" # サイト内商品検索・登録(商品が見つからない場合)
-      item_name = params[:item_name]&.strip
-
-      if item_name.blank?
-        @review.errors.add(:item_name, "商品名を入力してください")
-        return false
-      end
-
-      item = Item.find_or_initialize_by(name: item_name)
-      item.category ||= Category.find_by(name: "その他")
-
-    else
-      @review.errors.add(:item_name, "商品名を入力してください")
-      return false
-    end
-
-    unless item.save
-      @review.errors.add(:item_name, item.errors.full_messages.join(", "))
-      return false
-    end
-
-    @review.item = item
-    true
   end
 
   # レビューに関連付けられた商品に画像(1枚目)を添付する

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -153,6 +153,56 @@ class Review < ApplicationRecord
     notification.save if notification.valid?
   end
 
+  # 商品情報をパラメータに基づいて取得・作成し、レビューに関連付ける
+  # 処理失敗時はエラーを追加して false を返す
+  def assign_item_by_params(params)
+    item =
+      case params[:search_method] # Amazonまたはサイト内検索に応じてItemを取得・登録
+      when "amazon" # Amazon検索(デフォルト)
+        asin = params[:asin]&.strip                    # Amazonの商品コード（ASIN）
+        item_name = params[:amazon_item_name]&.strip  # Amazon検索候補で選択された商品名
+
+        # Amazonの商品が選択されていない場合はエラー
+        if asin.blank? || item_name.blank?
+          return error!(:amazon_item_name, "Amazonの商品を選択してください")
+        end
+
+        # ASINをもとに、商品登録または取得
+        fetched_item = fetch_amazon_info_if_needed(Item.find_or_initialize_by(asin: asin))
+
+        # 取得した商品に名前がない場合はエラー（取得失敗とみなす）
+        if fetched_item.name.blank?
+          return error!(:amazon_item_name, "商品情報の取得に失敗しました。もう一度お試しください")
+        end
+
+        fetched_item
+
+      when "minire" # サイト内商品検索・登録(商品が見つからない場合)
+        item_name = params[:item_name]&.strip  # サイト内検索で指定された商品名
+
+        if item_name.blank?
+          return error!(:item_name, "商品名を入力してください")
+        end
+
+        # 名前から商品を作成し、カテゴリ未設定であれば「その他」にする
+        Item.find_or_initialize_by(name: item_name).tap do |i|
+          i.category ||= Category.find_by(name: "その他")
+        end
+
+      else
+        # 想定外の search_method の場合もエラー
+        return error!(:item_name, "商品名を入力してください")
+      end
+
+    unless item.save
+      return error!(:item_name, item.errors.full_messages.join(", "))
+    end
+
+    # 商品をレビューに関連付け
+    self.item = item
+    true
+  end
+
   private
 
   # 空白は親要素を保存するタイミングで子モデルをまとめて削除
@@ -160,5 +210,21 @@ class Review < ApplicationRecord
     releasable_items.each do |item|
       item.mark_for_destruction if item.name.blank?
     end
+  end
+
+  # Amazon検索で取得したasinのItemが登録されていない場合のみ、Amazon APIから商品情報取得
+  def fetch_amazon_info_if_needed(item)
+    if item.asin.present? && item.last_updated_at.blank?
+      imported_item = AmazonItemImporter.new(item.asin).import!
+      return imported_item || item
+    end
+    # 既に登録済みであればDBから取得した情報を返す
+    item
+  end
+
+  # エラーを追加し、false を返す簡易メソッド
+  def error!(attr, message)
+    self.errors.add(attr, message)
+    false
   end
 end


### PR DESCRIPTION
### **概要**

このプルリクエストでは、レビュー作成時および更新時のアイテム関連付け処理をリファクタリングし、コントローラーからモデルに処理を移行しました。これにより、コードの再利用性と可読性が向上しました。

---

### **主な変更内容**

1. **アイテム関連付け処理のリファクタリング**:
    - コントローラー内に記述されていたアイテム関連付け処理をモデルに移動。
    - `assign_item_by_params` メソッドをモデルに追加し、レビューにアイテムを関連付ける処理を集約。
    - **対象ファイル**:
        - `app/controllers/reviews_controller.rb`
        - `app/models/review.rb`
2. **エラーハンドリングの改善**:
    - モデル内でのエラーハンドリングを簡略化し、エラー追加と処理の中断を統一的に処理 (`error!` メソッド追加)。
3. **Amazon API連携処理の整理**:
    - 商品情報が不足している場合にのみ Amazon API を利用して商品情報を補完する処理をモデルに移動 (`fetch_amazon_info_if_needed` メソッド追加)。

---

### **目的**

- コードの再利用性と保守性を高めるため、処理を適切なレイヤーに分離。
- コントローラーの責務を減らし、モデルにドメインロジックを集約。
- エラーハンドリングを一元化し、予期せぬ動作を防止。

---

### **関連コミット**

- [390771d1a68aeb939e4e58d3eb18a332421674e6](https://github.com/taka292/minire/commit/390771d1a68aeb939e4e58d3eb18a332421674e6)