### PR TITLE
コンソールで生じていたパラメーターのwarning抑止

### DIFF
--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -102,7 +102,7 @@ class ReviewsController < ApplicationController
   private
   # accepts_nested_attributes_forで削除するものを_destroyで追加
   def review_params
-    params.require(:review).permit(:title, :content, :category_id,  images: [], releasable_items_attributes: [ :id, :name, :_destroy ])
+    params.require(:review).permit(:title, :content, :category_id, :item_id, images: [], releasable_items_attributes: [ :id, :name, :_destroy ])
   end
 
   def set_review
@@ -121,8 +121,8 @@ class ReviewsController < ApplicationController
 
   # レビューの画像を削除する
   def handle_image_removal
-    if params[:review][:remove_images].present?
-      params[:review][:remove_images].split(",").each do |image_id|
+    if params[:remove_images].present?
+      params[:remove_images].split(",").each do |image_id|
         image = @review.images.find_by(id: image_id)
         image.purge if image
       end

--- a/app/views/reviews/_form.html.erb
+++ b/app/views/reviews/_form.html.erb
@@ -66,14 +66,14 @@
         autocomplete_url: items_path
       } %>
 
-  <%= form.hidden_field :name, data: { autocomplete_target: 'hidden' } %>
+  <%= form.hidden_field :item_id, data: { autocomplete_target: 'hidden' } %>
 
   <% if form.object.errors[:item_name].any? %>
     <p class="text-red-500 text-sm mt-1"><%= form.object.errors[:item_name].first %></p>
   <% end %>
 
   <ul class="list-group bg-white border border-gray-300 rounded-md shadow-md absolute top-full left-0 w-full md:text-sm max-w-max z-50" data-autocomplete-target="results"></ul>
-</div>
+  </div>
 </div>
 
 <div class="form-control mb-6">
@@ -129,7 +129,7 @@
     <% end %>
   </div>
 
-  <%= hidden_field_tag "review[remove_images]", "", data: { image_preview_target: "removeImages" } %>
+  <%= hidden_field_tag "remove_images", "", data: { image_preview_target: "removeImages" } %>
 
   <!-- エラーメッセージ -->
   <% if @review.errors[:images].present? %>


### PR DESCRIPTION
### **概要**

コンソールで発生していたパラメータ関連の警告を抑止するための修正を行いました。これにより、コードの動作がより安定し、不要な警告が解消されます。

---

### **主な変更内容**

1. **`review_params` の修正**:
    - `item_id` を許可パラメータに追加。
    - 画像削除用パラメータを `params[:review][:remove_images]` から `params[:remove_images]` に変更し、警告を抑止。
    - **対象ファイル**: `app/controllers/reviews_controller.rb`
2. **フォームビューの修正**:
    - 隠しフィールドの名前を修正し、警告を回避。
        - `review[name]` → `review[item_id]`
        - `review[remove_images]` → `remove_images`
    - **対象ファイル**: `app/views/reviews/_form.html.erb`

---

### **目的**

- コンソール上の警告を解消し、開発者が重要なエラーメッセージに集中できるようにする。
- コードの可読性と保守性を向上。

---

### **関連コミット**

- [b12ea1481d0af8eadd4f482be6cd91c00c48fab9](https://github.com/taka292/minire/commit/b12ea1481d0af8eadd4f482be6cd91c00c48fab9)