### PR TITLE
レビュー更新時にitem_idの上書きを防ぐため、paramsから除外する処理と関連テストを追加

### DIFF
--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -83,7 +83,8 @@ class ReviewsController < ApplicationController
       handle_image_removal
       @review.images.attach(params[:review][:images]) if params[:review][:images].present?
 
-      raise ActiveRecord::Rollback unless @review.update(review_params.except(:images))
+      # レビュー更新 (item_id はservice側で設定済みのため、paramsに含まれる空文字で上書きされるのを防ぐ)
+      raise ActiveRecord::Rollback unless @review.update(review_params.except(:images, :item_id))
       # attach_image_to_item_if_needed # 画像をitemに添付処理はリファクタリングとは別で対応
       redirect_to @review, notice: "レビューを更新しました！"
     end

--- a/spec/system/review_spec.rb
+++ b/spec/system/review_spec.rb
@@ -264,6 +264,29 @@ RSpec.describe "レビュー投稿機能", type: :system do
       expect(page).to have_css("img[src*='sample1.jpg']")
       expect(page).to have_css("img[src*='sample2.jpg']")
     end
+
+    it "MiniRe検索で新しい商品名を入力してレビューを編集できる" do
+      item = create(:item, name: "旧商品")
+      review = create(:review, user:, item:)
+
+      visit edit_review_path(review)
+
+      fill_in "item_name", with: "MiniRe編集商品" # 新しい商品名
+
+      fill_in "review[title]", with: "MiniRe編集後のタイトル"
+      fill_in "review[content]", with: "MiniRe編集後の内容"
+
+      click_button "更新する"
+
+      expect(page).to have_content("レビューを更新しました！")
+      expect(page).to have_content("MiniRe編集後のタイトル")
+      expect(page).to have_content("MiniRe編集後の内容")
+
+      updated_review = Review.find_by(title: "MiniRe編集後のタイトル")
+      expect(updated_review).to be_present
+      expect(updated_review.item.name).to eq("MiniRe編集商品")
+      expect(updated_review.item.category.name).to eq("その他")
+    end
   end
 
   describe "レビュー一覧・並び替え・絞り込み" do


### PR DESCRIPTION
### **概要**

レビュー更新時に商品の新規登録ができない問題に対して、 `item_id` が予期せず上書きされる問題を防ぐための修正と、その動作を確認するテストを追加しました。

---

### **主な変更内容**

1. **`item_id` 上書き防止の実装**:
    - `review_params` から `item_id` を除外し、空文字での上書きを防ぐ処理を追加。
    - **対象ファイル**: `app/controllers/reviews_controller.rb`
2. **システムテストの追加**:
    - MiniRe検索を使用し、新しい商品名を入力してレビューを編集するシナリオを追加。
    - 編集後のレビューおよび関連する商品情報が正しく更新されることを確認するテストケースを実装。
    - **対象ファイル**: `spec/system/review_spec.rb`

---

### **目的**

- `item_id` の不正な上書きを防ぐことで、レビュー編集時の商品新規登録を可能に。
- 新機能の動作保証のためのテストを追加し、品質を確保。