### PR TITLE
カテゴリのデフォルト値:その他を取得するメソッドを追加し、関連するコードをリファクタリング

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,5 +1,8 @@
 class Category < ApplicationRecord
-  # has_many :reviews
   has_many :items
   validates :name, presence: true, uniqueness: true
+
+  def self.default
+    find_by(name: "その他")
+  end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -2,12 +2,14 @@ class Item < ApplicationRecord
   has_many :reviews
   has_many_attached :images
   belongs_to :category, optional: true  # カテゴリが未設定の既存Itemに対応
-  # 空文字を許可せず、大文字小文字を区別せず、一意性を保証。
-  validates :name, presence: true, uniqueness: { case_sensitive: false }
+
+  validates :name, presence: true, uniqueness: { case_sensitive: false } # 空文字を許可せず、大文字小文字を区別せず、一意性を保証。
   validates :name, length: { minimum: 1 }
   validates :amazon_url, format: { with: URI.regexp(%w[http https]), message: "正しいURL形式を入力してください。" }, allow_blank: true
   validate :image_content_type
   validates :description, length: { maximum: 1000 }, allow_blank: true
+
+  before_validation :set_default_category
 
   # ファイル形式のバリデーション
   def image_content_type
@@ -25,5 +27,10 @@ class Item < ApplicationRecord
     images.map do |image|
       image.variant(resize_to_fill: [ 100, 100 ]).processed
     end
+  end
+
+  # カテゴリのデフォルト値(その他)を設定するメソッド
+  def set_default_category
+    self.category ||= Category.default
   end
 end

--- a/app/services/amazon_item_importer.rb
+++ b/app/services/amazon_item_importer.rb
@@ -55,7 +55,7 @@ class AmazonItemImporter
     mapped_category = mapped_name.present? ? Category.find_by(name: mapped_name) : nil
 
     # 4. item にカテゴリをセット（マッピングが見つかればそれを、なければ「その他」）
-    item.category = mapped_category || Category.find_by(name: "その他")
+    item.category = mapped_category || Category.default
 
     item.save! # Itemを保存（バリデーション失敗時は例外が発生）
 


### PR DESCRIPTION
### **概要**

カテゴリのデフォルト値「その他」を取得するためのメソッドを追加し、関連するコードをリファクタリングしました。これにより、デフォルトカテゴリの指定を一元化し、コードの保守性を向上させました。

---

### **主な変更内容**

1. **`Category` モデルへのデフォルトメソッド追加**:
    - `Category.default` メソッドを追加し、デフォルトカテゴリ「その他」を取得できるようにしました。
    - **対象ファイル**: `app/models/category.rb`
2. **`Item` モデルのリファクタリング**:
    - `before_validation` コールバックを追加し、カテゴリが設定されていない場合にデフォルトカテゴリを自動設定。
    - **対象ファイル**: `app/models/item.rb`
3. **Amazonアイテムインポーターの修正**:
    - デフォルトカテゴリの設定を直接文字列から `Category.default` メソッドに変更し、コードを統一。
    - **対象ファイル**: `app/services/amazon_item_importer.rb`

---

### **目的**

- デフォルトカテゴリ設定のロジックを統一し、コードの再利用性と可読性を向上。
- カテゴリ設定における冗長な記述を削減。

---

### **関連コミット**

- [c424f748c655337bd22c3cbcf6fc04018d17f1ec](https://github.com/taka292/minire/commit/c424f748c655337bd22c3cbcf6fc04018d17f1ec)