### PR TITLE
Feature/260 refactor code cleanup

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -58,11 +58,11 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   # The path used after sign up.
   def after_sign_up_path_for(resource)
-    home_index_path
+    root_path
   end
 
   # The path used after sign up for inactive accounts.
   def after_inactive_sign_up_path_for(resource)
-    home_index_path
+    root_path
   end
 end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -27,7 +27,7 @@ class Users::SessionsController < Devise::SessionsController
 
   def after_sign_in_path_for(resource)
     flash[:notice] = "ログインしました！さっそくレビューを投稿してみませんか？" unless resource.has_reviews?
-    home_index_path
+    root_path
   end
 
   def after_sign_out_path_for(resource_or_scope)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,7 +2,6 @@
 <html>
   <head>
     <title><%= content_for?(:title) ? yield(:title) : "MiniRe (ミニレ) | ミニマリスト向けのレビューサイト" %></title>
-    <meta name="description" content="<%= content_for?(:meta_description) ? yield(:meta_description) : '探さない、迷わない。MiniReがあるから。MiniReは、ミニマリストやシンプルライフを目指す人向けのレビューサイトです。厳選されたアイテムのレビューを参考にし、少ないモノで豊かに暮らすヒントを見つけましょう。' %>">
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <!-- 	フォーム送信時のCSRF対策用トークン -->

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,6 @@ Rails.application.routes.draw do
     passwords: "users/passwords",
     omniauth_callbacks: "users/omniauth_callbacks"
   }
-  get "home/index"
   root "home#index"
   resources :reviews do
     resources :comments, only: [ :create, :destroy, :edit, :update ]

--- a/spec/support/system_helper.rb
+++ b/spec/support/system_helper.rb
@@ -12,7 +12,7 @@ module SystemHelper
       fill_in "user[password]", with: "password"
       click_button "ログイン"
 
-      expect(page).to have_current_path(home_index_path, wait: 5)
+      expect(page).to have_current_path(root_path, wait: 5)
     end
   end
 end

--- a/spec/system/profile_spec.rb
+++ b/spec/system/profile_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe "プロフィール機能", type: :system do
       fill_in "user[password]", with: "newpassword"
       click_button "ログイン"
 
-      expect(page).to have_current_path(home_index_path)
+      expect(page).to have_current_path(root_path)
       expect(page).to have_content("ログインしました")
     end
 
@@ -225,7 +225,7 @@ RSpec.describe "プロフィール機能", type: :system do
 
       click_link "ログアウト"
 
-      expect(page).to have_content("ログアウトしました").or have_current_path(home_index_path)
+      expect(page).to have_content("ログアウトしました").or have_current_path(root_path)
     end
   end
 

--- a/spec/system/user_login_spec.rb
+++ b/spec/system/user_login_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "ユーザー認証", type: :system do
   it "正しい情報でログインできる(レビュー投稿無し)" do
     log_in(email: user.email, password: user.password)
 
-    expect(page).to have_current_path(home_index_path)
+    expect(page).to have_current_path(root_path)
     expect(page).to have_content("ログインしました")
     expect(page).to have_content("さっそくレビューを投稿してみませんか")
   end
@@ -22,7 +22,7 @@ RSpec.describe "ユーザー認証", type: :system do
     log_in(email: user.email, password: user.password)
     create(:review, user: user)
 
-    expect(page).to have_current_path(home_index_path)
+    expect(page).to have_current_path(root_path)
     expect(page).to have_content("ログインしました")
   end
 
@@ -42,7 +42,7 @@ RSpec.describe "ユーザー認証", type: :system do
 
   it "ログイン後にマイページにアクセスできる" do
     log_in(email: user.email, password: user.password)
-    expect(page).to have_current_path(home_index_path)
+    expect(page).to have_current_path(root_path)
 
     visit profile_path(user.id)
     expect(page).to have_current_path(profile_path(user.id))
@@ -58,7 +58,7 @@ RSpec.describe "ユーザー認証", type: :system do
     fill_in "user[password_confirmation]", with: "newpassword"
     click_button "登録する"
 
-    expect(page).to have_current_path(home_index_path)
+    expect(page).to have_current_path(root_path)
     expect(page).to have_content("登録ありがとうございます！さっそくレビューを投稿してみませんか？")
   end
 


### PR DESCRIPTION
### **タイトル**

**ルートパスの統一と不要なメタタグの削除**

---

### **概要**

このプルリクエストでは、以下の変更を行いました：

1. アクセス時のルートパスを `root_path` に統一。
2. 不要な `description` メタタグを削除し、コードを整理。

---

### **主な変更内容**

1. **ルートパスの統一**:
    - コントローラーやテストコード内のルートパスを `home_index_path` から `root_path` に修正。
    - コードの一貫性を保つために、複数箇所で該当箇所を変更。
    - **対象ファイル**:
        - `app/controllers/users/registrations_controller.rb`
        - `app/controllers/users/sessions_controller.rb`
        - `config/routes.rb`
        - 各システムテスト (`spec/system`)
2. **不要なメタタグの削除**:
    - レイアウトファイル内で重複していた `description` メタタグを削除。
    - **対象ファイル**:
        - `app/views/layouts/application.html.erb`

---

### **目的**

- ルートパスの統一により、メンテナンス性を向上。
- 不要なメタタグの削除でコードベースをシンプルに保つ。

---

### **統合されたコミット**

- [1732a34f7b5207a03cedffd4670734a5acc5007b](https://github.com/taka292/minire/commit/1732a34f7b5207a03cedffd4670734a5acc5007b): ホームページアクセスに関するルートパスを統一。
- [8ddef09f241a3aa6859f05f6fcde58dcba4e2324](https://github.com/taka292/minire/commit/8ddef09f241a3aa6859f05f6fcde58dcba4e2324): メタタグの重複を削除。