### PR TITLE
レビューフォームの各部分をパーシャル化

### DIFF
--- a/app/views/reviews/_amazon_search_form.html.erb
+++ b/app/views/reviews/_amazon_search_form.html.erb
@@ -1,0 +1,35 @@
+<!-- Amazon検索フォーム -->
+<div id="amazon-form" class="form-control mb-6 relative" data-controller="autocomplete" data-autocomplete-url-value="<%= amazon_index_path %>">
+  <!-- 商品名ラベルとMiniReボタンを横並びに -->
+  <div class="flex items-center justify-between mb-1">
+    <%= form.label :amazon_item_name, class: "text-lg font-medium text-gray-700" do %>
+      商品名 <span class="text-red-500">*</span>
+    <% end %>
+
+    <div class="mb-4">
+      <button type="button"
+              class="text-sm text-blue-600 underline"
+              data-action="click->search-toggle#showMinire">
+        見つからない場合
+      </button>
+    </div>
+  </div>
+
+  <%= text_field_tag :amazon_item_name, nil,
+      placeholder: "6文字以上のAmazonの商品名を入力してください",
+      class: "input input-bordered w-full h-12 text-lg placeholder:text-sm #{error_class(@review, :amazon_item_name)}", 
+      data: {
+        autocomplete_target: "input",
+        autocomplete_url: amazon_index_path
+      } %>
+
+  <%= hidden_field_tag :asin, nil, data: { autocomplete_target: "hidden" } %>
+
+  <% if form.object.errors[:amazon_item_name].any? %>
+    <p class="text-red-500 text-sm mt-1"><%= form.object.errors[:amazon_item_name].first %></p>
+  <% end %>
+
+  <ul class="list-group bg-white border border-gray-300 rounded-md shadow-md absolute top-full left-0 w-full md:text-sm max-w-max z-50"
+      data-autocomplete-target="results">
+  </ul>
+</div>

--- a/app/views/reviews/_content_form.html.erb
+++ b/app/views/reviews/_content_form.html.erb
@@ -1,0 +1,26 @@
+<!-- 内容フォーム -->
+<div class="form-control mb-6" data-controller="template">
+  <div class="flex items-center justify-between mb-1">
+    <%= form.label :content, class: "text-lg font-medium text-gray-700" do %>
+      内容 <span class="text-red-500">*</span>
+    <% end %>
+
+    <button type="button" class="btn btn-outline btn-sm" data-action="click->template#insert">
+      テンプレートを挿入
+    </button>
+  </div>
+
+  <%= form.text_area :content,
+      rows: 3,
+      class: "textarea textarea-bordered w-full text-lg resize-y placeholder:text-sm #{error_class(@review, :content)}",
+      placeholder: "レビュー内容を入力してください",
+      data: {
+        controller: "autosize",
+        action: "input->autosize#resize",
+        template_target: "textarea"
+      } %>
+
+  <% if form.object.errors[:content].any? %>
+    <p class="text-red-500 text-sm mt-1"><%= form.object.errors[:content].first %></p>
+  <% end %>
+</div>

--- a/app/views/reviews/_form.html.erb
+++ b/app/views/reviews/_form.html.erb
@@ -1,3 +1,4 @@
+<!-- 商品名検索フォーム -->
 <div data-controller="search-toggle">
   <!-- 検索方法の状態を伝える hidden フィールド -->
   <!-- action_name が edit の場合は 'minire' をデフォルトに -->
@@ -5,162 +6,23 @@
   <%= hidden_field_tag :search_method, params[:search_method] || (action_name == 'edit' ? 'minire' : 'amazon'), id: "search_method" %>
 
   <!-- Amazon検索フォーム -->
-  <div id="amazon-form" class="form-control mb-6 relative" data-controller="autocomplete" data-autocomplete-url-value="<%= amazon_index_path %>">
-    <!-- 商品名ラベルとMiniReボタンを横並びに -->
-    <div class="flex items-center justify-between mb-1">
-      <%= form.label :amazon_item_name, class: "text-lg font-medium text-gray-700" do %>
-        商品名 <span class="text-red-500">*</span>
-      <% end %>
-
-      <div class="mb-4">
-        <button type="button"
-                class="text-sm text-blue-600 underline"
-                data-action="click->search-toggle#showMinire">
-          見つからない場合
-        </button>
-      </div>
-    </div>
-
-    <%= text_field_tag :amazon_item_name, nil,
-        placeholder: "6文字以上のAmazonの商品名を入力してください",
-        class: "input input-bordered w-full h-12 text-lg placeholder:text-sm #{error_class(@review, :amazon_item_name)}", 
-        data: {
-          autocomplete_target: "input",
-          autocomplete_url: amazon_index_path
-        } %>
-
-    <%= hidden_field_tag :asin, nil, data: { autocomplete_target: "hidden" } %>
-
-    <% if form.object.errors[:amazon_item_name].any? %>
-      <p class="text-red-500 text-sm mt-1"><%= form.object.errors[:amazon_item_name].first %></p>
-    <% end %>
-
-    <ul class="list-group bg-white border border-gray-300 rounded-md shadow-md absolute top-full left-0 w-full md:text-sm max-w-max z-50"
-        data-autocomplete-target="results">
-    </ul>
-  </div>
+  <%= render "amazon_search_form", form: form, review: @review %>
 
   <!-- 登録アイテムフォーム -->
-  <div id="minire-form" class="form-control mb-6 relative" data-controller="autocomplete" data-autocomplete-url-value="<%= items_path %>">
-    <!-- 商品名ラベルとAmazonボタンを横並びに -->
-    <div class="flex items-center justify-between mb-1">
-      <%= form.label :item_name, class: "text-lg font-medium text-gray-700" do %>
-        商品名 <span class="text-red-500">*</span>
-      <% end %>
-
-      <div>
-        <button type="button"
-                class="text-sm text-blue-600 underline"
-                data-action="click->search-toggle#showAmazon">
-          Amazon内で探す
-        </button>
-      </div>
-    </div>
-
-    <%= text_field_tag :item_name, @review.item&.name,
-        placeholder: "商品名を登録してください", 
-        class: "input input-bordered w-full h-12 text-lg placeholder:text-sm #{error_class(@review, :item_name)}", 
-        data: { 
-          autocomplete_target: "input", 
-          autocomplete_url: items_path
-        } %>
-
-    <%= form.hidden_field :item_id, data: { autocomplete_target: 'hidden' } %>
-
-    <% if form.object.errors[:item_name].any? %>
-      <p class="text-red-500 text-sm mt-1"><%= form.object.errors[:item_name].first %></p>
-    <% end %>
-
-    <ul class="list-group bg-white border border-gray-300 rounded-md shadow-md absolute top-full left-0 w-full md:text-sm max-w-max z-50" data-autocomplete-target="results"></ul>
-  </div>
+  <%= render "minire_search_form", form: form, review: @review %>
 </div>
 
-<div class="form-control mb-6">
-  <%= form.label :title, class: "block text-lg font-medium text-gray-700" do  %>
-    タイトル <span class="text-red-500">*</span>
-  <% end %>
-  <%= form.text_field :title, class: "input input-bordered w-full h-12 text-lg placeholder:text-sm #{error_class(@review, :title)}", placeholder: "レビュータイトルを入力してください" %>
-  <% if form.object.errors[:title].any? %>
-    <p class="text-red-500 text-sm mt-1"><%= form.object.errors[:title].first %></p>
-  <% end %>
-</div>
+<!-- タイトルフォーム -->
+<%= render "title_form", form: form, review: @review %>
 
-<div class="form-control mb-6" data-controller="template">
-  <div class="flex items-center justify-between mb-1">
-    <%= form.label :content, class: "text-lg font-medium text-gray-700" do %>
-      内容 <span class="text-red-500">*</span>
-    <% end %>
+<!-- 内容フォーム -->
+<%= render "content_form", form: form, review: @review %>
 
-    <button type="button" class="btn btn-outline btn-sm" data-action="click->template#insert">
-      テンプレートを挿入
-    </button>
-  </div>
+<!-- 画像アップロードフォーム -->
+<%= render "image_upload_form", form: form, review: @review %>
 
-  <%= form.text_area :content,
-      rows: 3,
-      class: "textarea textarea-bordered w-full text-lg resize-y placeholder:text-sm #{error_class(@review, :content)}",
-      placeholder: "レビュー内容を入力してください",
-      data: {
-        controller: "autosize",
-        action: "input->autosize#resize",
-        template_target: "textarea"
-      } %>
+<!-- 手放せるものフォーム -->
+<%= render "releasable_items_fields", form: form, review: @review %>
 
-  <% if form.object.errors[:content].any? %>
-    <p class="text-red-500 text-sm mt-1"><%= form.object.errors[:content].first %></p>
-  <% end %>
-</div>
-
-<!-- 画像アップロード -->
-<div class="form-control mb-6" data-controller="image-preview">
-  <%= form.label :images, "レビュー画像（5枚まで選択可）", class: "block text-lg font-medium text-gray-700" %>
-
-  <!-- 画像プレビューエリア -->
-  <div data-image-preview-target="preview" class="flex flex-wrap gap-2 mb-4">
-    <% @review.images.each do |image| %>
-      <% if image.persisted? %>
-        <div class="relative preview-image" data-image-id="<%= image.id %>">
-          <%= image_tag image.variant(resize_to_limit: [200, 200]), class: "w-24 h-24 object-cover border" %>
-        </div>
-      <% end %>
-    <% end %>
-  </div>
-
-  <%= hidden_field_tag "remove_images", "", data: { image_preview_target: "removeImages" } %>
-
-  <!-- エラーメッセージ -->
-  <% if @review.errors[:images].present? %>
-    <p class="text-red-500 text-sm mt-1"><%= @review.errors[:images].first %></p>
-  <% end %>
-
-  <!-- 画像選択フィールド -->
-  <div class="form-control mb-4">
-    <%= form.file_field :images, name: "review[images][]", multiple: true, class: "file-input file-input-bordered w-full #{error_class(@review, :images)}", data: { image_preview_target: "input" }, id: "image-input", "data-action": "change->image-preview#selectImages" %>
-  </div>
-</div>
-
-<div data-controller="releasable-items">
-  <!-- タイトル：最初は hidden にしておく -->
-  <%= form.label :releasable_items, "手放せるもの（任意・最大3つまで）", class: "block text-lg font-medium text-gray-700 mb-2 hidden", data: { releasable_items_target: "title" } %>
-
-  <% 3.times do |i| %>
-    <% value_present = @review.releasable_items[i]&.name.present? %>
-    <div data-releasable-items-target="item" class="<%= 'hidden' unless value_present %>">
-      <%= form.fields_for :releasable_items, @review.releasable_items[i] || ReleasableItem.new, child_index: i do |item_fields| %>
-        <%= render "reviews/releasable_items_form", item_fields: item_fields, index: i %>
-      <% end %>
-    </div>
-  <% end %>
-
-  <div class="mt-4 text-right">
-    <button type="button"
-            class="btn btn-outline btn-sm"
-            data-action="click->releasable-items#add">
-      手放せるものを追加
-    </button>
-  </div>
-</div>
-
-<div class="form-control mt-6">
-  <%= form.submit button_label, class: "btn bg-customBlue text-white border-0 hover:bg-blue-500 w-full py-3 text-lg" %>
-</div>
+<!-- 投稿ボタン-->
+<%= render "shared/form_submit", form: form, button_label: button_label %>

--- a/app/views/reviews/_image_upload_form.html.erb
+++ b/app/views/reviews/_image_upload_form.html.erb
@@ -1,0 +1,27 @@
+<!-- 画像アップロードフォーム -->
+<div class="form-control mb-6" data-controller="image-preview">
+  <%= form.label :images, "レビュー画像（5枚まで選択可）", class: "block text-lg font-medium text-gray-700" %>
+
+  <!-- 画像プレビューエリア -->
+  <div data-image-preview-target="preview" class="flex flex-wrap gap-2 mb-4">
+    <% @review.images.each do |image| %>
+      <% if image.persisted? %>
+        <div class="relative preview-image" data-image-id="<%= image.id %>">
+          <%= image_tag image.variant(resize_to_limit: [200, 200]), class: "w-24 h-24 object-cover border" %>
+        </div>
+      <% end %>
+    <% end %>
+  </div>
+
+  <%= hidden_field_tag "remove_images", "", data: { image_preview_target: "removeImages" } %>
+
+  <!-- エラーメッセージ -->
+  <% if @review.errors[:images].present? %>
+    <p class="text-red-500 text-sm mt-1"><%= @review.errors[:images].first %></p>
+  <% end %>
+
+  <!-- 画像選択フィールド -->
+  <div class="form-control mb-4">
+    <%= form.file_field :images, name: "review[images][]", multiple: true, class: "file-input file-input-bordered w-full #{error_class(@review, :images)}", data: { image_preview_target: "input" }, id: "image-input", "data-action": "change->image-preview#selectImages" %>
+  </div>
+</div>

--- a/app/views/reviews/_minire_search_form.html.erb
+++ b/app/views/reviews/_minire_search_form.html.erb
@@ -1,0 +1,33 @@
+<!-- 登録アイテムフォーム -->
+<div id="minire-form" class="form-control mb-6 relative" data-controller="autocomplete" data-autocomplete-url-value="<%= items_path %>">
+  <!-- 商品名ラベルとAmazonボタンを横並びに -->
+  <div class="flex items-center justify-between mb-1">
+    <%= form.label :item_name, class: "text-lg font-medium text-gray-700" do %>
+      商品名 <span class="text-red-500">*</span>
+    <% end %>
+
+    <div>
+      <button type="button"
+              class="text-sm text-blue-600 underline"
+              data-action="click->search-toggle#showAmazon">
+        Amazon内で探す
+      </button>
+    </div>
+  </div>
+
+  <%= text_field_tag :item_name, @review.item&.name,
+      placeholder: "商品名を登録してください", 
+      class: "input input-bordered w-full h-12 text-lg placeholder:text-sm #{error_class(@review, :item_name)}", 
+      data: { 
+        autocomplete_target: "input", 
+        autocomplete_url: items_path
+      } %>
+
+  <%= form.hidden_field :item_id, data: { autocomplete_target: 'hidden' } %>
+
+  <% if form.object.errors[:item_name].any? %>
+    <p class="text-red-500 text-sm mt-1"><%= form.object.errors[:item_name].first %></p>
+  <% end %>
+
+  <ul class="list-group bg-white border border-gray-300 rounded-md shadow-md absolute top-full left-0 w-full md:text-sm max-w-max z-50" data-autocomplete-target="results"></ul>
+</div>

--- a/app/views/reviews/_releasable_items_fields.html.erb
+++ b/app/views/reviews/_releasable_items_fields.html.erb
@@ -1,0 +1,22 @@
+<!-- 手放せるものフォーム -->
+<div data-controller="releasable-items">
+  <!-- タイトル：最初は hidden にしておく -->
+  <%= form.label :releasable_items, "手放せるもの（任意・最大3つまで）", class: "block text-lg font-medium text-gray-700 mb-2 hidden", data: { releasable_items_target: "title" } %>
+
+  <% 3.times do |i| %>
+    <% value_present = @review.releasable_items[i]&.name.present? %>
+    <div data-releasable-items-target="item" class="<%= 'hidden' unless value_present %>">
+      <%= form.fields_for :releasable_items, @review.releasable_items[i] || ReleasableItem.new, child_index: i do |item_fields| %>
+        <%= render "reviews/releasable_items_form", item_fields: item_fields, index: i %>
+      <% end %>
+    </div>
+  <% end %>
+
+  <div class="mt-4 text-right">
+    <button type="button"
+            class="btn btn-outline btn-sm"
+            data-action="click->releasable-items#add">
+      手放せるものを追加
+    </button>
+  </div>
+</div>

--- a/app/views/reviews/_title_form.html.erb
+++ b/app/views/reviews/_title_form.html.erb
@@ -1,0 +1,10 @@
+<!-- タイトルフォーム -->
+<div class="form-control mb-6">
+  <%= form.label :title, class: "block text-lg font-medium text-gray-700" do  %>
+    タイトル <span class="text-red-500">*</span>
+  <% end %>
+  <%= form.text_field :title, class: "input input-bordered w-full h-12 text-lg placeholder:text-sm #{error_class(@review, :title)}", placeholder: "レビュータイトルを入力してください" %>
+  <% if form.object.errors[:title].any? %>
+    <p class="text-red-500 text-sm mt-1"><%= form.object.errors[:title].first %></p>
+  <% end %>
+</div>

--- a/app/views/shared/_form_submit.html.erb
+++ b/app/views/shared/_form_submit.html.erb
@@ -1,0 +1,4 @@
+<!-- 投稿ボタン-->
+<div class="form-control mt-6">
+  <%= form.submit button_label, class: "btn bg-customBlue text-white border-0 hover:bg-blue-500 w-full py-3 text-lg" %>
+</div>


### PR DESCRIPTION
### **概要**

レビュー投稿フォームの各セクションをパーシャル化し、コードの再利用性と可読性を向上させました。

---

### **主な変更内容**

1. **フォームのパーシャル化**:
    - 投稿フォームを以下のパーシャルに分割しました：
        - `_amazon_search_form.html.erb` (Amazon検索フォーム)
        - `_minire_search_form.html.erb` (MiniRe検索フォーム)
        - `_title_form.html.erb` (タイトルフォーム)
        - `_content_form.html.erb` (内容フォーム)
        - `_image_upload_form.html.erb` (画像アップロードフォーム)
        - `_releasable_items_fields.html.erb` (手放せるものフォーム)
        - `_form_submit.html.erb` (投稿ボタン)
2. **コード削減**:
    - `app/views/reviews/_form.html.erb` のコード行数を削減し、各セクションをパーシャル化。
    - 可読性が向上し、変更やメンテナンスが容易に。

---

### **目的**

- コードの重複を避け、再利用性を高める。
- 長いフォームコードをセクションごとに分割し、可読性を向上。
- フォームの構成要素をより分かりやすく整理。

---

### **関連コミット**

- [1ce87b762e59a66c15f4cb182a3d5f635754cde0](https://github.com/taka292/minire/commit/1ce87b762e59a66c15f4cb182a3d5f635754cde0): レビューフォームの各部分をパーシャル化。