### PR TITLE
商品名検索切り替えの不要な余白を削除

### DIFF
--- a/app/views/reviews/_amazon_search_form.html.erb
+++ b/app/views/reviews/_amazon_search_form.html.erb
@@ -6,7 +6,7 @@
       商品名 <span class="text-red-500">*</span>
     <% end %>
 
-    <div class="mb-4">
+    <div>
       <button type="button"
               class="text-sm text-blue-600 underline"
               data-action="click->search-toggle#showMinire">


### PR DESCRIPTION
### **概要**

このプルリクエストでは、商品名検索フォーム内の切り替えボタンに関する不要な余白を削除し、デザインの一貫性を向上させました。

---

### **主な変更内容**

1. **不要な余白の削除**:
    - ボタン周囲の余白 (`mb-4`) を削除し、ビューの見た目を調整。
    - **対象ファイル**: `app/views/reviews/_amazon_search_form.html.erb`

---

### **目的**

- 無駄なスペースを減らし、フォーム内の要素配置を簡潔にすることで、より洗練されたデザインを実現。

---

### **関連コミット**

- [024ec613ac06b175dbd68d8aa7b75b780151343d](https://github.com/taka292/minire/commit/024ec613ac06b175dbd68d8aa7b75b780151343d): 商品名検索切り替えの不要な余白を削除。