### PR TITLE
冗長なItem保存処理を削除し、商品のAmazon情報取得エラー判定をnilに合わせて調整

### DIFF
--- a/app/services/amazon_item_importer.rb
+++ b/app/services/amazon_item_importer.rb
@@ -57,8 +57,6 @@ class AmazonItemImporter
     # 4. item にカテゴリをセット（マッピングが見つかればそれを、なければ「その他」）
     item.category = mapped_category || Category.default
 
-    item.save! # Itemを保存（バリデーション失敗時は例外が発生）
-
     item # 最終的に保存したItemを返す
   rescue => e
     # 何らかのエラーが発生した場合はログに出力してnilを返す

--- a/app/services/review_item_assignment_service.rb
+++ b/app/services/review_item_assignment_service.rb
@@ -48,7 +48,7 @@ class ReviewItemAssignmentService
     item = fetch_amazon_info_if_needed(Item.find_or_initialize_by(asin: asin))
 
     # 商品情報が不完全（例：名前がない）場合はエラー
-    if item.name.blank?
+    if item.nil?
       return error!(:amazon_item_name, "商品情報の取得に失敗しました。もう一度お試しください")
     end
 


### PR DESCRIPTION

### **概要**

保存処理の効率化とエラー処理の改善を行いました。

---

### **主な変更内容**

1. **冗長な`Item`保存処理の削除**:
    - `AmazonItemImporter`サービス内での不要な`item.save!`処理を削除。
    - これにより冗長な保存処理を排除し、エラー発生時の例外処理を簡潔化。
    - **対象ファイル**: `app/services/amazon_item_importer.rb`
2. **Amazon情報取得エラー判定の修正**:
    - 商品情報取得エラー判定を`item.name.blank?`から`item.nil?`に変更。
    - これにより、商品情報が`nil`の場合のエラー処理が適切に行われるよう調整。
    - **対象ファイル**: `app/services/review_item_assignment_service.rb`

---

### **目的**

- 冗長なコードを削除して可読性を向上。
- Amazon情報取得時のエラー判定を明確化し、エラー処理の精度を向上。

---

### **関連コミット**

- [cb946346ba7088120ff5edbb4d0ee02a2d0dfa75](https://github.com/taka292/minire/commit/cb946346ba7088120ff5edbb4d0ee02a2d0dfa75): 冗長なItem保存処理を削除し、商品のAmazon情報取得エラー判定をnilに合わせて調整。