### PR TITLE
refactor : Amazon・サイト内検索フォームのオートコンプリート表示の横幅調整とスクロール化

### DIFF
--- a/app/views/reviews/_amazon_search_form.html.erb
+++ b/app/views/reviews/_amazon_search_form.html.erb
@@ -29,7 +29,7 @@
     <p class="text-red-500 text-sm mt-1"><%= form.object.errors[:amazon_item_name].first %></p>
   <% end %>
 
-  <ul class="list-group bg-white border border-gray-300 rounded-md shadow-md absolute top-full left-0 w-full md:text-sm max-w-max z-50"
+  <ul class="list-group bg-white border border-gray-300 rounded-md shadow-md absolute top-full left-0 w-full z-10 max-h-[60vh] overflow-y-auto"
       data-autocomplete-target="results">
   </ul>
 </div>

--- a/app/views/reviews/_missing_on_amazon_form.html.erb
+++ b/app/views/reviews/_missing_on_amazon_form.html.erb
@@ -29,5 +29,5 @@
     <p class="text-red-500 text-sm mt-1"><%= form.object.errors[:item_name].first %></p>
   <% end %>
 
-  <ul class="list-group bg-white border border-gray-300 rounded-md shadow-md absolute top-full left-0 w-full md:text-sm max-w-max z-50" data-autocomplete-target="results"></ul>
+  <ul class="list-group bg-white border border-gray-300 rounded-md shadow-md absolute top-full left-0 w-full z-10 max-h-[60vh] overflow-y-auto" data-autocomplete-target="results"></ul>
 </div>


### PR DESCRIPTION
### **概要**

レビュー投稿ページのAmazon検索フォームおよびサイト内検索フォームのオートコンプリートリスト表示を改善しました。これにより、リストの表示領域が調整され、ユーザー体験が向上します。

---

### **主な変更内容**

1. **オートコンプリートリストの横幅調整**:
    - `w-full` クラスを使用して、リストの横幅をフォーム全体に合わせました。
    - **対象ファイル**:
        - `app/views/reviews/_amazon_search_form.html.erb`
        - `app/views/reviews/_missing_on_amazon_form.html.erb`
2. **スクロール可能なリストの実装**:
    - オートコンプリートリストに`max-h-[60vh]`と`overflow-y-auto`を追加し、リストの高さを最大60vhに制限。
    - 長いリストが生成された場合でも、スクロールで全ての候補を確認可能。
3. **z-indexの調整**:
    - `z-10`を使用して、リストの表示優先順位を調整。

---

### **目的**

- オートコンプリートリストの表示が視覚的にわかりやすくなるように改善。
- リストが長くなるケースでも、スクロール可能にすることで操作性を向上。

---

### **関連コミット**

- [1c102cf8c4e7620231ff7a77490c367b77e97ead](https://github.com/taka292/minire/commit/1c102cf8c4e7620231ff7a77490c367b77e97ead): Amazon・サイト内検索フォームのオートコンプリート表示の横幅調整とスクロール化。