### PR TITLE
ui : 検索フォームのplace folderの文言を改善

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -12,7 +12,7 @@
     <div class="hidden md:flex flex-1 ml-8 h-16 items-center">
       <%= search_form_for @q, url: reviews_path, method: :get, html: { class: "flex md:w-[400px] items-center gap-2" } do |f| %>
         <%= f.search_field review_search_field,
-              placeholder: "商品名・キーワード",
+              placeholder: "レビュー・商品・手放せるもの",
               class: "input input-bordered md:w-[300px] h-10 px-3 text-base placeholder-gray-400"%>
 
         <%= f.submit "検索", class: "btn h-10 min-h-0 bg-customBlue text-white border-none px-4" %>
@@ -128,7 +128,7 @@
     <div class="mt-2 h-14 flex items-center">
       <%= search_form_for @q, url: reviews_path, method: :get, html: { class: "flex items-center gap-2 w-full" } do |f|%>
         <%= f.search_field review_search_field,
-        placeholder: "商品名・キーワード", class: "input input-bordered w-full placeholder-gray-400 h-10 text-base px-3"%>
+        placeholder: "レビュー・商品・手放せるもの", class: "input input-bordered w-full placeholder-gray-400 h-10 text-base px-3"%>
         <%= submit_tag "検索", class: "btn min-h-0 h-10 bg-customBlue text-white border-none px-4" %>
       <% end %>
     </div>


### PR DESCRIPTION
### **概要**

検索フォームのプレースホルダ文言をより直感的なものに改善しました。これにより、ユーザーが検索フォームの用途を理解しやすくなり、レビューや商品、手放せるものを検索する際の利便性が向上します。

---

### **主な変更内容**

1. **プレースホルダ文言の変更**:
    - 旧文言: 「商品名・キーワード」
    - 新文言: 「レビュー・商品・手放せるもの」
    - **変更箇所**:
        - ヘッダー部分の検索フォーム（デスクトップ版とモバイル版）
    - **対象ファイル**:
        - `app/views/layouts/_header.html.erb`

---

### **目的**

- ユーザーが検索機能の対象範囲（レビュー、商品、手放せるもの）をより明確に理解できるようにする。
- 利用者の検索体験を向上させるためのUI改善。

---

### **関連コミット**

- [45017e2492d45869a7b1933b3550dfb7f799ec3f](https://github.com/taka292/minire/commit/45017e2492d45869a7b1933b3550dfb7f799ec3f): 検索フォームのplace folderの文言を改善。