### PR TITLE
refactor : ビューのコメントを一部、開発者モードで閲覧できないように修正

### DIFF
--- a/app/views/admin/items/index.html.erb
+++ b/app/views/admin/items/index.html.erb
@@ -4,7 +4,7 @@
 
   <% registered_items, unregistered_items = @items.partition { |item| item.amazon_url.present? && item.asin.present? } %>
 
-  <!-- 🔴 未登録セクション -->
+  <!-- 未登録セクション -->
   <% if unregistered_items.any? %>
     <div class="bg-red-50 border border-red-300 rounded-md p-4 mb-6 shadow">
       <h2 class="text-red-600 text-lg font-bold mb-2">Amazon情報が未登録の商品（<%= unregistered_items.count %>件）</h2>
@@ -33,7 +33,7 @@
     </div>
   <% end %>
 
-  <!-- ✅ 登録済みセクション -->
+  <!-- 登録済みセクション -->
   <div class="bg-white border border-gray-300 rounded-md shadow-sm">
     <h2 class="text-lg font-semibold text-gray-700 p-4 border-b">Amazon情報が登録されている商品（<%= registered_items.count %>件）</h2>
     <table class="table-auto w-full text-sm">

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,7 +1,7 @@
   <%= turbo_frame_tag dom_id(comment) do %>
     <li class="flex items-start space-x-4 py-2">
       <!-- ユーザーのアバター -->
-      <!-- 通常のページ遷移をしようとすると、遷移先でturbo-frameを探してエラーになるため、通常のページ遷移（リロード）を行うよう明示 -->
+      <%# 通常のページ遷移をしようとすると、遷移先でturbo-frameを探してエラーになるため、通常のページ遷移（リロード）を行うよう明示 %>
       <%= link_to profile_path(comment.user), class: "flex-shrink-0", data: { turbo_frame: "_top" } do %>
         <% if comment.user.has_valid_avatar? %>
           <%= image_tag comment.user.avatar.variant(resize_to_fill: [40, 40]), class: "rounded-full w-10 h-10" %>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -57,7 +57,7 @@
             <% end %>
           </div>
 
-          <!-- SNSログインではなく、メールアドレスでのログインの場合のみ更新可能 -->
+          <%# SNSログインではなく、メールアドレスでのログインの場合のみ更新可能 %>
           <% unless @user.provider.present? %>
             <div class="form-control mt-4">
               <%= link_to "メールアドレスの変更", edit_email_profile_path(@user), class: "text-blue-500 hover:text-blue-700 underline" %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -19,10 +19,10 @@
       <p class="ml-4 text-lg font-medium text-gray-800"><%= @user.name %></p>
     </div>
 
-    <!-- 投稿数・フォロワー数・フォロー数 -->
+    <%# 投稿数・フォロワー数・フォロー数 %>
     <div class="flex space-x-6 mb-4">
       <p>投稿数: <strong><%= @user.reviews.count %></strong></p>
-      <!-- フォロワー数・フォロー数はここに後で追加予定 -->
+      <%# フォロワー数・フォロー数はここに後で追加予定 %>
     </div>
     <!-- 自己紹介文 -->
     <div class="mb-4">
@@ -45,7 +45,7 @@
     <% end %>
   </div>
 
-  <!-- レビュー切り替え(いいね一覧への遷移先のため、id指定) -->
+  <%# レビュー切り替え(いいね一覧への遷移先のため、id指定) %>
   <div class="card bg-white shadow-lg rounded-lg p-6" id="likes">
     <div class="flex flex-col sm:flex-row space-y-2 sm:space-y-0 sm:space-x-4 mb-4">
       <%= link_to "過去のレビュー", 

--- a/app/views/reviews/_form.html.erb
+++ b/app/views/reviews/_form.html.erb
@@ -1,8 +1,8 @@
 <!-- 商品名検索フォーム -->
 <div data-controller="search-toggle">
-  <!-- 検索方法の状態を伝える hidden フィールド -->
-  <!-- action_name が edit の場合は 'サイト内検索(見つからない場合はこちら)' をデフォルトに -->
-  <!-- それ以外は 'amazon検索' をデフォルトに -->
+  <%# 検索方法の状態を伝える hidden フィールド
+      action_name が edit の場合は 'サイト内検索(見つからない場合はこちら)' をデフォルトに
+      それ以外は 'amazon検索' をデフォルトに %>
   <%= hidden_field_tag :search_method, params[:search_method] || (action_name == 'edit' ? 'missing_on_amazon' : 'amazon'), id: "search_method" %>
 
   <!-- Amazon検索フォーム -->

--- a/app/views/reviews/_missing_on_amazon_form.html.erb
+++ b/app/views/reviews/_missing_on_amazon_form.html.erb
@@ -1,6 +1,6 @@
 <!-- サイト内検索フォーム -->
 <div id="missing-on-amazon-form" class="form-control mb-6 relative" data-controller="autocomplete" data-autocomplete-url-value="<%= items_path %>">
-  <!-- 商品名ラベルとAmazonボタンを横並びに -->
+  <%# 商品名ラベルとAmazonボタンを横並びに %>
   <div class="flex items-center justify-between mb-1">
     <%= form.label :item_name, class: "text-lg font-medium text-gray-700" do %>
       商品名 <span class="text-red-500">*</span>

--- a/app/views/reviews/_releasable_items_fields.html.erb
+++ b/app/views/reviews/_releasable_items_fields.html.erb
@@ -1,6 +1,6 @@
 <!-- 手放せるものフォーム -->
 <div data-controller="releasable-items">
-  <!-- タイトル：最初は hidden にしておく -->
+  <%# タイトル：最初は hidden にしておく %>
   <%= form.label :releasable_items, "手放せるもの（任意・最大3つまで）", class: "block text-lg font-medium text-gray-700 mb-2 hidden", data: { releasable_items_target: "title" } %>
 
   <% 3.times do |i| %>

--- a/app/views/reviews/show.html.erb
+++ b/app/views/reviews/show.html.erb
@@ -1,20 +1,20 @@
 <!-- レビュー詳細ページ -->
-<!-- タイトル・内容 -->
+<%# タイトル・内容 %>
 <%  "#{@review.title} | MiniRe (ミニレ)" %>
 <% content_for :meta_description, "#{@review.title} というテーマで、おすすめのアイテムや使い方についてレビューされています。'}" %>
-<!-- Xシェア用情報 -->
+<%# Xシェア用情報 %>
 <% content_for :og_title, @review.title %>
 <% content_for :og_description, truncate(@review.content, length: 100) %>
-<!-- OGP画像(Xでの表示用にリサイズ) -->
+<%# OGP画像(Xでの表示用にリサイズ) %>
 <% if @review.images.attached? %>
   <% x_ogp_image = @review.images.first.variant(resize_to_fill: [1200, 630]).processed %>
-  <!-- リサイズされた画像のURLを取得 -->
+  <%# リサイズされた画像のURLを取得 %>
   <% ogp_image_url = rails_representation_url(x_ogp_image, only_path: false) %>
   <% content_for :og_image, ogp_image_url %>
 <% else %>
   <% content_for :og_image, image_url("ogp.png") %>
 <% end %>
-<!--パンくずリスト-->
+<%#パンくずリスト %>
 <% breadcrumb :review, @review %>
 
 <div class="container mx-auto px-4 py-8">

--- a/app/views/shared/_review_card.html.erb
+++ b/app/views/shared/_review_card.html.erb
@@ -69,7 +69,7 @@
           <% if review.item.manufacturer.present? %>
             <p class="text-sm text-gray-500"><%= review.item.manufacturer %></p>
           <% end %>
-          <!-- 商品名(長過ぎる名前もあるため、70文字まで表示) -->
+          <%# 商品名(長過ぎる名前もあるため、70文字まで表示) %>
           <% if review.item.name.present? %>
             <p class="text-md text-gray-800 font-medium underline"><%= truncate(review.item.name, length: 70) %></p>
           <% end %>

--- a/app/views/shared/_review_like_button.html.erb
+++ b/app/views/shared/_review_like_button.html.erb
@@ -17,7 +17,7 @@
     <% end %>
   <% end %>
 <% else %>
-  <!-- 未ログイン時: クリック不可のアイコンを表示 -->
+  <%# 未ログイン時: クリック不可のアイコンを表示 %>
   <span class="flex items-center text-gray-500 cursor-not-allowed" title="ログインするといいねできます">
     <span class="material-icons text-2xl">favorite_border</span>
   </span>

--- a/app/views/shared/_review_list.html.erb
+++ b/app/views/shared/_review_list.html.erb
@@ -3,7 +3,7 @@
     <h1 class="text-2xl font-bold mb-6 text-center"><%= title %></h1>
   <% end %>
 
-  <!--filter_formがtrueの場合、絞り込み・並び替えフォームを表示する-->
+  <%# filter_formがtrueの場合、絞り込み・並び替えフォームを表示する %>
   <% if filter_form %>
     <form method="get" action="<%= path %>" class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6 max-w-screen-lg mx-auto">
 


### PR DESCRIPTION
### **概要**

ビュー内の一部コメントを通常出力 (`<!-- ... -->`) から開発者モード専用 (`<%# ... %>`) 形式に変更し、HTML上にコメントが表示されないようにしました。これにより、ユーザー側には不要なコメントがHTMLに出力されなくなります。

---

### **主な変更内容**

- `<!-- ... -->` 形式で記載されていたビューコメントの多くを `<%# ... %>` 形式に修正し、HTML上に出力されないよう統一
    - 管理画面（商品一覧）、コメント表示、プロフィール編集・表示、レビュー作成・詳細、レビュー共通パーツなど
-ユーザーインターフェース・表示内容に影響なし

---

### **目的**

- HTML出力のクリーンアップ
- 不要なコメントがユーザーに見えないようにすることで、セキュリティ・可読性の向上
- 開発者向けのメモ等はRailsテンプレート内でのみ確認可能にする

---

### **関連コミット**

- [9bdf8e1a8fa667889dd3a6e907e71ff9bf1000d4](https://github.com/taka292/minire/commit/9bdf8e1a8fa667889dd3a6e907e71ff9bf1000d4): ビューのコメントを一部、開発者モードで閲覧できないように修正