### PR TITLE
add : 検索フォームのカテゴリ絞り込み・並び順状態保持機能の追加＋組み合わせテストの追加

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -15,6 +15,12 @@
               placeholder: "レビュー・商品・手放せるもの",
               class: "input input-bordered md:w-[300px] h-10 px-3 text-base placeholder-gray-400"%>
 
+        <%# カテゴリ絞り込みの状態を保持 %>
+        <%= hidden_field_tag :filter_type, params[:filter_type] if params[:filter_type].present? %>
+
+        <%# 並び順の状態を保持 %>
+        <%= hidden_field_tag :sort, params[:sort] if params[:sort].present? %>
+
         <%= f.submit "検索", class: "btn h-10 min-h-0 bg-customBlue text-white border-none px-4" %>
       <% end %>
     </div>

--- a/app/views/shared/_review_list.html.erb
+++ b/app/views/shared/_review_list.html.erb
@@ -8,8 +8,7 @@
     <form method="get" action="<%= path %>" class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6 max-w-screen-lg mx-auto">
 
       <%#  検索クエリを保持する hidden フィールド(ないと絞り込みフォームと合わせての検索ができない) %>
-      <%= hidden_field_tag "q[title_or_content_or_item_name_cont]", params.dig(:q, :title_or_content_or_item_name_cont) %>
-
+      <%= hidden_field_tag "q[#{review_search_field}]", params.dig(:q, review_search_field) %>
       <!-- 絞り込みフォーム -->
       <div class="flex flex-col md:flex-row  min-w-[300px]">
         <label for="filter_type" class="text-sm font-medium text-gray-600 whitespace-nowrap min-w-fit md:mr-2">絞り込み:</label>


### PR DESCRIPTION
### **概要**
    検索フォームで「カテゴリ絞り込み」と「並び順」の選択状態を保持する機能を追加しました。  
    - 検索時にカテゴリや並び替えを維持できるよう、hiddenフィールドを自動で付与。
    - 検索条件(hidden)のロジックの統一性を向上。

    上記機能に対し、カテゴリ絞り込みや並び順切替とキーワード検索を組み合わせたシステムテストを追加しました。    
    - 複数条件組み合わせ（カテゴリ＋いいね順＋キーワード）での動作を検証するテストケースを強化。
    - テストヘルパーメソッドの追加・整理。

---

### **主な変更ファイル**

- `app/views/layouts/_header.html.erb`
    - 検索フォームにカテゴリ・並び順状態保持用hiddenフィールド追加
- `app/views/shared/_review_list.html.erb`
    - 検索条件hiddenフィールドのロジック見直し
- `spec/system/review_spec.rb`
    - カテゴリ・並び順・キーワードの組み合わせテスト追加
    - テストヘルパー追加・リファクタリング

---

### **目的**

- ユーザーが「カテゴリ」や「並び順」を指定して検索した後も、その選択状態を維持できるようにし、検索体験を向上。
- 複雑な検索条件の組み合わせに対しても、システムテストで確実に保証。