### PR TITLE
add : pg_trgmインデックスを追加して検索性能を向上

### DIFF
--- a/db/migrate/20250520024443_add_trgm_indexes_for_search.rb
+++ b/db/migrate/20250520024443_add_trgm_indexes_for_search.rb
@@ -1,0 +1,19 @@
+class AddTrgmIndexesForSearch < ActiveRecord::Migration[7.2]
+  def change
+    enable_extension "pg_trgm" unless extension_enabled?("pg_trgm")
+
+    # reviews
+    execute "CREATE INDEX index_reviews_on_title_trgm ON reviews USING gin (title gin_trgm_ops)" unless index_exists?(:reviews, :title, name: "index_reviews_on_title_trgm")
+    execute "CREATE INDEX index_reviews_on_content_trgm ON reviews USING gin (content gin_trgm_ops)" unless index_exists?(:reviews, :content, name: "index_reviews_on_content_trgm")
+    add_index :reviews, :created_at unless index_exists?(:reviews, :created_at)
+
+    # items
+    execute "CREATE INDEX index_items_on_name_trgm ON items USING gin (name gin_trgm_ops)" unless index_exists?(:items, :name, name: "index_items_on_name_trgm")
+    execute "CREATE INDEX index_items_on_description_trgm ON items USING gin (description gin_trgm_ops)" unless index_exists?(:items, :description, name: "index_items_on_description_trgm")
+    execute "CREATE INDEX index_items_on_manufacturer_trgm ON items USING gin (manufacturer gin_trgm_ops)" unless index_exists?(:items, :manufacturer, name: "index_items_on_manufacturer_trgm")
+    execute "CREATE INDEX index_items_on_asin_trgm ON items USING gin (asin gin_trgm_ops)" unless index_exists?(:items, :asin, name: "index_items_on_asin_trgm")
+
+    # releasable_items
+    execute "CREATE INDEX index_releasable_items_on_name_trgm ON releasable_items USING gin (name gin_trgm_ops)" unless index_exists?(:releasable_items, :name, name: "index_releasable_items_on_name_trgm")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_05_08_111840) do
+ActiveRecord::Schema[7.2].define(version: 2025_05_20_024443) do
   # These are extensions that must be enabled in order to support this database
+  enable_extension "pg_trgm"
   enable_extension "plpgsql"
 
   create_table "active_storage_attachments", force: :cascade do |t|
@@ -72,7 +73,11 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_08_111840) do
     t.datetime "updated_at", null: false
     t.text "description"
     t.integer "category_id"
+    t.index ["asin"], name: "index_items_on_asin_trgm", opclass: :gin_trgm_ops, using: :gin
     t.index ["category_id"], name: "index_items_on_category_id"
+    t.index ["description"], name: "index_items_on_description_trgm", opclass: :gin_trgm_ops, using: :gin
+    t.index ["manufacturer"], name: "index_items_on_manufacturer_trgm", opclass: :gin_trgm_ops, using: :gin
+    t.index ["name"], name: "index_items_on_name_trgm", opclass: :gin_trgm_ops, using: :gin
   end
 
   create_table "likes", force: :cascade do |t|
@@ -104,6 +109,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_08_111840) do
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_releasable_items_on_name_trgm", opclass: :gin_trgm_ops, using: :gin
     t.index ["review_id"], name: "index_releasable_items_on_review_id"
   end
 
@@ -114,7 +120,10 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_08_111840) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "item_id"
+    t.index ["content"], name: "index_reviews_on_content_trgm", opclass: :gin_trgm_ops, using: :gin
+    t.index ["created_at"], name: "index_reviews_on_created_at"
     t.index ["item_id"], name: "index_reviews_on_item_id"
+    t.index ["title"], name: "index_reviews_on_title_trgm", opclass: :gin_trgm_ops, using: :gin
     t.index ["user_id"], name: "index_reviews_on_user_id"
   end
 


### PR DESCRIPTION
### **概要**

全文検索のパフォーマンス向上を目的として、`pg_trgm`エクステンションおよび複数カラムへのGINインデックスを追加しました。

---

### **主な変更点**

- `pg_trgm`エクステンションを有効化
- 検索対象となる以下のテーブル・カラムにGINインデックス（trigram検索用）を追加
    - reviews: `title`, `content`
    - items: `name`, `description`, `manufacturer`, `asin`
    - releasable_items: `name`
- `reviews`テーブルの`created_at`カラムにもインデックスを追加
- スキーマファイルの更新

---

### **目的**

- レビューや商品等の検索機能の体感速度を改善
- 部分一致やあいまい検索の際のDB負荷を軽減

---

### **参考コミット**

- [989385c0390f8a9f8d5ad71a64eac17bf0b37671](https://github.com/taka292/minire/commit/989385c0390f8a9f8d5ad71a64eac17bf0b37671): pg_trgmインデックスを追加して検索性能を向上