### PR TITLE
ユーザー登録直後のリダイレクト先変更・UI微調整

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -10,15 +10,9 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # end
 
   # POST /resource
-  def create
-    super do |resource|
-      if resource.persisted?
-        flash[:notice] = "登録ありがとうございます！さっそくレビューを投稿してみませんか？"
-      elsif resource.errors.any? # もしエラーがあれば
-        flash[:alert] = I18n.t("devise.registrations.failure") # カスタムメッセージを設定
-      end
-    end
-  end
+  # def edit
+  #   super
+  # end
 
   # GET /resource/edit
   # def edit
@@ -57,8 +51,9 @@ class Users::RegistrationsController < Devise::RegistrationsController
   end
 
   # The path used after sign up.
+  # ユーザー登録後のリダイレクト先でプロフィール編集画面を指定
   def after_sign_up_path_for(resource)
-    root_path
+    edit_profile_path(resource)
   end
 
   # The path used after sign up for inactive accounts.

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -55,16 +55,16 @@
       </div>
     </div>
 
-    <!-- パスワードリセットリンク -->
-    <p class="text-center mt-4 text-sm">
-      パスワードをお忘れですか？
-      <%= link_to "こちらから再設定", new_password_path(resource_name), class: "link link-primary font-semibold text-sm" %>
-    </p>
-
     <!-- サインアップリンク -->
     <p class="text-center mt-4 text-sm">
       アカウントをお持ちでない方は
       <%= link_to "新規登録", new_registration_path(resource_name), class: "link link-primary font-semibold text-sm" %>
+    </p>
+
+    <!-- パスワードリセットリンク -->
+    <p class="text-center mt-4 text-sm">
+      パスワードをお忘れですか？
+      <%= link_to "こちらから再設定", new_password_path(resource_name), class: "link link-primary font-semibold text-sm" %>
     </p>
   </div>
 </div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -34,6 +34,11 @@
         <% end %>
       <% end %>
 
+      <%= link_to new_review_path, class: "flex flex-col items-center justify-center text-gray-600" do %>
+          <span class="material-symbols-outlined text-3xl leading-none">rate_review</span>
+          <span class="mt-0.5">投稿</span>
+        <% end %>
+
       <%= link_to reviews_path, class: "flex flex-col items-center justify-center text-gray-600", title: "レビュー 一覧" do %>
         <span class="material-symbols-outlined text-3xl leading-none">quick_reference_all</span>
         <span class="mt-0.5">投稿一覧</span>

--- a/app/views/reviews/_releasable_items_fields.html.erb
+++ b/app/views/reviews/_releasable_items_fields.html.erb
@@ -1,7 +1,8 @@
 <!-- 手放せるものフォーム -->
-<div data-controller="releasable-items">
+<div data-controller="releasable-items" class="space-y-4">
+
   <%# タイトル：最初は hidden にしておく %>
-  <%= form.label :releasable_items, "手放せるもの（任意・最大3つまで）", class: "block text-lg font-medium text-gray-700 mb-2 hidden", data: { releasable_items_target: "title" } %>
+  <%= form.label :releasable_items, "手放せるもの（任意・最大3つまで）", class: "block text-lg font-semibold text-gray-800 hidden", data: { releasable_items_target: "title" } %>
 
   <% 3.times do |i| %>
     <% value_present = @review.releasable_items[i]&.name.present? %>
@@ -12,11 +13,11 @@
     </div>
   <% end %>
 
-  <div class="mt-4 text-right">
+  <div class="flex justify-center mt-2">
     <button type="button"
-            class="btn btn-outline btn-sm"
+            class="btn btn-outline btn-primary btn-sm px-6"
             data-action="click->releasable-items#add">
-      手放せるものを追加
+      ＋ 手放せるものを追加
     </button>
   </div>
 </div>

--- a/app/views/reviews/new.html.erb
+++ b/app/views/reviews/new.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, "レビュー投稿 | MiniRe (ミニレ)" %>
 <% breadcrumb :new_review %>
-<div class="bg-gray-100 min-h-screen py-8 px-4">
+<div class="bg-gray-100 min-h-screen py-4 px-4">
   <div class="max-w-4xl mx-auto">
     <%= form_with model: @review, local: true do |f| %>
       <%= render "reviews/form", form: f, button_label: "投稿する" %>

--- a/app/views/shared/_review_card.html.erb
+++ b/app/views/shared/_review_card.html.erb
@@ -14,15 +14,6 @@
   <!-- レビュー内容 -->
   <div class="clickable-area flex flex-col flex-1">
     <%= link_to review_path(review), class: "block hover:no-underline text-inherit" do %>
-      <!-- 投稿写真 -->
-      <div class="mb-4 grid grid-cols-3 gap-3">
-        <% if review.images.attached? %>
-          <% review.resized_images.take(3).each do |image| %>
-            <%= image_tag image, alt: "投稿写真", class: "aspect-square rounded-md col-span-1 object-cover" %>
-          <% end %>
-        <% end %>
-      </div>
-
       <!-- 投稿タイトル -->
       <h2 class="text-lg font-bold text-gray-900 mb-2"><%= review.title %></h2>
 
@@ -31,6 +22,15 @@
         <p class="text-sm text-gray-700 mb-4 truncate overflow-hidden">
           <%= truncate(review.content, length: 100) %>
         </p>
+      </div>
+
+      <!-- 投稿写真 -->
+      <div class="mb-4 grid grid-cols-3 gap-3">
+        <% if review.images.attached? %>
+          <% review.resized_images.take(3).each do |image| %>
+            <%= image_tag image, alt: "投稿写真", class: "aspect-square rounded-md col-span-1 object-cover" %>
+          <% end %>
+        <% end %>
       </div>
     <% end %>
   </div>

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -6,7 +6,7 @@ ja:
       signed_in: "ログインしました!"
       signed_out: "ログアウトしました。"
     registrations:
-      signed_up: "登録ありがとうございます！さっそくレビューを投稿してみませんか？"
+      signed_up: "登録ありがとうございます！まずは必要に応じてプロフィールを設定してみましょう!"
       failure: 'アカウントの登録に失敗しました。入力内容を確認してください。'
     passwords:
       send_instructions: "パスワード再設定のためのメールを送信しました。"

--- a/spec/system/user_login_spec.rb
+++ b/spec/system/user_login_spec.rb
@@ -58,8 +58,8 @@ RSpec.describe "ユーザー認証", type: :system do
     fill_in "user[password_confirmation]", with: "newpassword"
     click_button "登録する"
 
-    expect(page).to have_current_path(root_path)
-    expect(page).to have_content("登録ありがとうございます！さっそくレビューを投稿してみませんか？")
+    expect(page).to have_current_path(edit_profile_path(User.last), wait: 5)
+    expect(page).to have_content("登録ありがとうございます！まずは必要に応じてプロフィールを設定してみましょう!")
   end
 
   it "メールアドレス未入力では登録できない" do


### PR DESCRIPTION
### **概要**

- [81495c2bc7cf4f39647b59aa8383c36e701207a7](https://github.com/taka292/minire/commit/81495c2bc7cf4f39647b59aa8383c36e701207a7)
    
    レビューカードの投稿写真表示位置・フォームスタイルの調整、ヘッダーに「投稿」ボタン追加等、UI・UXの微調整。
    
- [5c0751928fa0bcd5cc251d34e8aee40925e330a6](https://github.com/taka292/minire/commit/5c0751928fa0bcd5cc251d34e8aee40925e330a6)
    
    ユーザー新規登録直後のリダイレクト先を「プロフィール編集画面」へ変更し、案内メッセージも合わせて更新。テストも新仕様に対応。
    

---

### **主な修正内容**

- ユーザー登録直後、プロフィール編集画面にリダイレクトされるよう仕様変更
- 登録完了時のメッセージ文言を「まずはプロフィールを設定しましょう」に変更
- テストコード（system/user_login_spec.rb）もリダイレクト先・文言修正に対応
- 投稿フォームやレビューカードのUI調整（画像表示位置入れ替え、ボタンレイアウト修正など）
- ヘッダーに「投稿」ボタン追加

---

### **影響範囲**

- 新規登録体験（リダイレクト先・メッセージ）
- 投稿フォーム・一覧UI
- テスト