### PR TITLE
画像ギャラリー機能の実装とレイアウト/UIスタイル改善

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -6,9 +6,17 @@ body {
   @apply bg-[#F5F5F5] text-gray-900;
 }
 
+/* lightbox(画像の拡大機能)のスタイル */
 .lightbox .lb-image {
   max-width: 80vw;
-  /* 画面の80%の幅に */
   max-height: 80vh;
-  /* 画面の80%の高さに */
+}
+
+/* スワイパー(画像スライド)のスタイル */
+.swiper-container {
+  position: relative;
+}
+
+.swiper-pagination {
+  bottom: -25px !important;
 }

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -5,3 +5,10 @@
 body {
   @apply bg-[#F5F5F5] text-gray-900;
 }
+
+.lightbox .lb-image {
+  max-width: 80vw;
+  /* 画面の80%の幅に */
+  max-height: 80vh;
+  /* 画面の80%の高さに */
+}

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,24 @@
 // Entry point for the build script in your package.json
 import "@hotwired/turbo-rails"
 import "./controllers"
+
+// app/javascript/application.js
+// import Swiper from 'swiper/bundle'
+// import 'swiper/css/bundle'
+
+// SwiperをTurboに対応させて初期化
+document.addEventListener('turbo:load', () => {
+  const carousels = document.querySelectorAll('.swiper')
+
+  carousels.forEach((carousel) => {
+    new Swiper(carousel, {
+      loop: false,
+      slidesPerView: 1,
+      spaceBetween: 16,
+      pagination: {
+        el: carousel.querySelector('.swiper-pagination'),
+        clickable: true,
+      }
+    })
+  })
+})

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -2,21 +2,19 @@
 import "@hotwired/turbo-rails"
 import "./controllers"
 
-// app/javascript/application.js
-// import Swiper from 'swiper/bundle'
-// import 'swiper/css/bundle'
-
 // SwiperをTurboに対応させて初期化
 document.addEventListener('turbo:load', () => {
-  const carousels = document.querySelectorAll('.swiper')
+  const containers = document.querySelectorAll('.swiper-container')
 
-  carousels.forEach((carousel) => {
-    new Swiper(carousel, {
+  containers.forEach((container) => {
+    const swiperEl = container.querySelector('.swiper')
+
+    new Swiper(swiperEl, {
       loop: false,
       slidesPerView: 1,
       spaceBetween: 16,
       pagination: {
-        el: carousel.querySelector('.swiper-pagination'),
+        el: container.querySelector('.swiper-pagination'),
         clickable: true,
       }
     })

--- a/app/javascript/controllers/image_gallery_controller.js
+++ b/app/javascript/controllers/image_gallery_controller.js
@@ -1,0 +1,26 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["main", "thumbnail"]
+
+  connect() {
+    this.highlight(0) // 初期選択を強調
+  }
+
+  change(event) {
+    const largeUrl = event.currentTarget.dataset.large
+    const index = parseInt(event.currentTarget.dataset.index)
+    this.mainTarget.src = largeUrl
+    this.highlight(index)
+  }
+
+  highlight(index) {
+    this.thumbnailTargets.forEach((el, i) => {
+      el.classList.toggle("border-2", i === index)
+      el.classList.toggle("border-blue-500", i === index)
+      el.classList.toggle("border-transparent", i !== index)
+      el.classList.toggle("opacity-100", i === index)
+      el.classList.toggle("opacity-60", i !== index)
+    })
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -4,26 +4,23 @@
 
 import { application } from "./application"
 
-// 商品名の自動補完（Amazon検索やサイト内検索に対応）
-import Autocomplete from "stimulus-autocomplete"
-application.register("autocomplete", Autocomplete)
+import AutosizeController from "./autosize_controller"
+application.register("autosize", AutosizeController)
 
-// 手放せるものフォーム追加
+import FormToggleController from "./form_toggle_controller"
+application.register("form-toggle", FormToggleController)
+
+import ImageGalleryController from "./image_gallery_controller"
+application.register("image-gallery", ImageGalleryController)
+
+import ImagePreviewController from "./image_preview_controller"
+application.register("image-preview", ImagePreviewController)
+
 import ReleasableItemsController from "./releasable_items_controller"
 application.register("releasable-items", ReleasableItemsController)
 
-// 画像プレビューの表示
-import ImagePreviewController from "./image_preview_controller";
-application.register("image-preview", ImagePreviewController);
-
-// 商品検索フォーム（Amazon / サイト内）の表示切り替え
 import SearchToggleController from "./search_toggle_controller"
 application.register("search-toggle", SearchToggleController)
 
-// レビュー内容にテンプレート文を挿入できるボタン操作を提供
 import TemplateController from "./template_controller"
 application.register("template", TemplateController)
-
-// テキストエリアのサイズを入力内容に応じて自動調整
-import AutosizeController from "./autosize_controller"
-application.register("autosize", AutosizeController)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -38,6 +38,18 @@
     <!-- JavaScript -->
     <link rel="preload" href="/assets/application-33583849.js" as="script" crossorigin="anonymous">
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module", defer: true, crossorigin: "anonymous" %>
+
+    
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/lightbox2/2.11.3/css/lightbox.min.css" rel="stylesheet">
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/lightbox2/2.11.3/js/lightbox.min.js" defer></script>
+    <script>
+    lightbox.option({
+      'resizeDuration': 200,
+      'wrapAround': true
+    })
+    </script>
+    <link rel="stylesheet" href="https://unpkg.com/swiper/swiper-bundle.min.css">
   </head>
   <body class="font-sans">
     <div class="bg-[#F5F5F5] border-b border-black shadow-md  sticky top-0 z-50">
@@ -64,7 +76,7 @@
     <%= render 'layouts/footer' %>
 
     <!-- レビュー投稿ボタン -->
-    <%= link_to new_review_path, class: "fixed flex flex-col items-center justify-center bottom-4 right-4 bg-white text-gray-800 border border-gray-300 w-16 h-16 rounded-full shadow-md hover:bg-gray-100 transition text-[10px] sm:text-xs", title: "レビュー投稿" do %>
+    <%= link_to new_review_path, class: "block md:hidden fixed flex flex-col items-center justify-center bottom-4 right-4 bg-white text-gray-800 border border-gray-300 w-16 h-16 rounded-full shadow-md hover:bg-gray-100 transition text-[10px] sm:text-xs", title: "レビュー投稿" do %>
       <span class="material-icons text-2xl leading-none" aria-hidden="true">rate_review</span>
       <span class="mt-0.5">投稿</span>
     <% end %>
@@ -79,6 +91,8 @@
         offset: 60
       });
     </script>
+
+    <script src="https://unpkg.com/swiper/swiper-bundle.min.js"></script>
 
   </body>
 </html>

--- a/app/views/reviews/_review_body.html.erb
+++ b/app/views/reviews/_review_body.html.erb
@@ -1,0 +1,19 @@
+<!-- レビューの本文部分を表示するためのテンプレート -->
+<h1 class="text-2xl font-bold mt-8 mb-4 text-gray-800"><%= review.title %></h1>
+<div class="text-base text-gray-700 mb-6">
+  <%= simple_format(review.content) %>
+</div>
+
+<% if review.releasable_items.present? %>
+  <div class="p-4 bg-gray-100 rounded-md">
+    <h2 class="text-lg font-semibold mb-2">手放せるもの</h2>
+    <ul class="space-y-2">
+      <% review.releasable_items.each do |item| %>
+        <li class="flex items-center text-gray-700 text-lg">
+          <span class="material-symbols-outlined text-blue-500 mr-2">check_circle</span>
+          <%= item.name %>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/reviews/show.html.erb
+++ b/app/views/reviews/show.html.erb
@@ -38,39 +38,115 @@
       <% end %>
     </div>
 
-    <!-- 投稿写真 -->
-    <div class="flex space-x-4 overflow-x-auto">
-        <% if @review.images.attached? %>
-          <% @review.resized_images.each do |image| %>
-            <%= image_tag image,
-                          class: "aspect-square rounded-md col-span-1 object-cover flex-none",
-                          alt: "投稿写真" %>
-          <% end %>
-        <% end %>
-    </div>
+    <div class="container mx-auto px-4 py-8">
+      <!-- 投稿画像 + 内容：スマホとPCで切り替え -->
+      <div>
 
-    <!-- 投稿タイトル -->
-    <h1 class="text-2xl font-bold mb-6"><%= @review.title %></h1>
+        <!-- スマホのみ表示 -->
+        <div class="block md:hidden">
+          <!-- Swiperカルーセル本体 -->
+          <div class="swiper w-full rounded-lg overflow-hidden mb-4">
+            <div class="swiper-wrapper">
+              <% @review.images.each do |image| %>
+                <div class="swiper-slide flex justify-center items-center bg-white">
+                  <%= link_to url_for(image), data: { lightbox: "review-images" } do %>
+                    <%= image_tag image.variant(resize_to_limit: [600, 600]),
+                                  class: "max-h-[300px] w-auto mx-auto object-contain" %>
+                  <% end %>
+                </div>
+              <% end %>
+            </div>
+            <!-- ドットを画像の外・下に表示 -->
+            <div class="swiper-pagination mt-4 flex justify-center">
+              <div class="swiper-button-prev"></div>
+              <div class="swiper-button-next"></div>
+            </div>
+          </div>
 
-    <!-- 投稿本文 -->
-    <div class="mb-6 text-gray-700 text-sm">
-      <%= safe_join(@review.content.split("\n"), tag(:br)) %>
-    </div>
+          
 
-    <!-- 手放せるもの -->
-    <% if @review.releasable_items.present? %>
-      <div class="mb-6 p-4 bg-gray-100 rounded-lg">
-        <h2 class="text-lg font-bold mb-2 text-gray-800">手放せるもの</h2>
-        <ul class="space-y-2">
-          <% @review.releasable_items.each do |item| %>
-            <li class="flex items-center text-gray-700">
-              <span class="material-symbols-outlined text-blue-500 mr-2">check_circle</span>
-              <%= item.name %>
-            </li>
-          <% end %>
-        </ul>
+          <!-- 本文・タイトル・手放せるもの -->
+          <div class="mt-6 space-y-6">
+            <!-- タイトル -->
+            <h1 class="text-xl font-bold text-gray-800"><%= @review.title %></h1>
+
+            <!-- 本文 -->
+            <div class="text-base text-gray-700">
+              <%= simple_format(@review.content) %>
+            </div>
+
+            <!-- 手放せるもの -->
+            <% if @review.releasable_items.present? %>
+              <div class="p-4 bg-gray-100 rounded-md">
+                <h2 class="text-lg font-semibold mb-2">手放せるもの</h2>
+                <ul class="space-y-2">
+                  <% @review.releasable_items.each do |item| %>
+                    <li class="flex items-center text-gray-700 text-base">
+                      <span class="material-symbols-outlined text-blue-500 mr-2">check_circle</span>
+                      <%= item.name %>
+                    </li>
+                  <% end %>
+                </ul>
+              </div>
+            <% end %>
+          </div>
+        </div>
+
+
+        <!-- PC表示（画像＋サムネイル＋本文） -->
+        <div class="hidden md:flex flex-row gap-6" data-controller="image-gallery">
+          <!-- 左側：画像・サムネイル -->
+          <div class="w-1/2 flex flex-col items-start">
+            <% if @review.images.attached? %>
+              <!-- メイン画像 -->
+              <img data-image-gallery-target="main"
+                  src="<%= url_for(@review.images.first.variant(resize_to_limit: [600, 600])) %>"
+                  class="w-full max-h-[400px] object-contain rounded-md mb-4">
+
+              <!-- サムネイル -->
+              <div class="flex gap-2 overflow-x-auto">
+                <div class="flex gap-2 overflow-x-auto">
+                  <% @review.images.each_with_index do |image, index| %>
+                    <img src="<%= url_for(image.variant(resize_to_fill: [100, 100])) %>"
+                        data-image-gallery-target="thumbnail"
+                        data-action="click->image-gallery#change"
+                        data-large="<%= url_for(image.variant(resize_to_limit: [600, 600])) %>"
+                        data-index="<%= index %>"
+                        class="w-20 h-20 object-cover rounded-md cursor-pointer
+                                transition duration-150 ease-in-out">
+                  <% end %>
+                </div>
+              </div>
+            <% end %>
+          </div>
+
+          <!-- 右側：本文や手放せるもの -->
+          <div class="w-1/2">
+            <h1 class="text-2xl font-bold mb-4 text-gray-800"><%= @review.title %></h1>
+            <div class="text-base text-gray-700 mb-6">
+              <%= simple_format(@review.content) %>
+            </div>
+
+            <% if @review.releasable_items.present? %>
+              <div class="p-4 bg-gray-100 rounded-md">
+                <h2 class="text-lg font-semibold mb-2">手放せるもの</h2>
+                <ul class="space-y-2">
+                  <% @review.releasable_items.each do |item| %>
+                    <li class="flex items-center text-gray-700 text-lg">
+                      <span class="material-symbols-outlined text-blue-500 mr-2">check_circle</span>
+                      <%= item.name %>
+                    </li>
+                  <% end %>
+                </ul>
+              </div>
+            <% end %>
+          </div>
+        </div>
+
       </div>
-    <% end %>
+    </div>
+
+
 
 
     <!-- 編集・削除ボタン -->

--- a/app/views/reviews/show.html.erb
+++ b/app/views/reviews/show.html.erb
@@ -1,7 +1,5 @@
 <!-- レビュー詳細ページ -->
-<%# タイトル・内容 %>
-<%  "#{@review.title} | MiniRe (ミニレ)" %>
-<% content_for :meta_description, "#{@review.title} というテーマで、おすすめのアイテムや使い方についてレビューされています。'}" %>
+<% content_for :meta_description, "#{@review.title} というテーマで、おすすめのアイテムや使い方についてレビューされています。" %>
 <%# Xシェア用情報 %>
 <% content_for :og_title, @review.title %>
 <% content_for :og_description, truncate(@review.content, length: 100) %>
@@ -28,126 +26,78 @@
                         class: "w-12 h-12 rounded-full object-cover",
                         alt: "User Avatar" %>
         <% else %>
-          <span class="material-symbols-outlined text-gray-600 text-3xl">account_circle</span>
+          <span class="material-symbols-outlined text-gray-600 flex items-center justify-center w-10 h-10" style="font-size: 40px;">account_circle</span>
         <% end %>
         <div class="ml-4 text-gray-800 font-medium">
-          <p class="text-sm">
+          <p class="ml-4 text-sm text-gray-800 font-medium">
             <%= @review.user.name %>
           </p>
         </div>
       <% end %>
     </div>
 
-    <div class="container mx-auto px-4 py-8">
-      <!-- 投稿画像 + 内容：スマホとPCで切り替え -->
-      <div>
-
-        <!-- スマホのみ表示 -->
-        <div class="block md:hidden">
-          <!-- Swiperカルーセル本体 -->
-          <div class="swiper w-full rounded-lg overflow-hidden mb-4">
-            <div class="swiper-wrapper">
-              <% @review.images.each do |image| %>
-                <div class="swiper-slide flex justify-center items-center bg-white">
-                  <%= link_to url_for(image), data: { lightbox: "review-images" } do %>
-                    <%= image_tag image.variant(resize_to_limit: [600, 600]),
-                                  class: "max-h-[300px] w-auto mx-auto object-contain" %>
-                  <% end %>
-                </div>
-              <% end %>
-            </div>
-            <!-- ドットを画像の外・下に表示 -->
-            <div class="swiper-pagination mt-4 flex justify-center">
-              <div class="swiper-button-prev"></div>
-              <div class="swiper-button-next"></div>
-            </div>
-          </div>
-
-          
-
-          <!-- 本文・タイトル・手放せるもの -->
-          <div class="mt-6 space-y-6">
-            <!-- タイトル -->
-            <h1 class="text-xl font-bold text-gray-800"><%= @review.title %></h1>
-
-            <!-- 本文 -->
-            <div class="text-base text-gray-700">
-              <%= simple_format(@review.content) %>
-            </div>
-
-            <!-- 手放せるもの -->
-            <% if @review.releasable_items.present? %>
-              <div class="p-4 bg-gray-100 rounded-md">
-                <h2 class="text-lg font-semibold mb-2">手放せるもの</h2>
-                <ul class="space-y-2">
-                  <% @review.releasable_items.each do |item| %>
-                    <li class="flex items-center text-gray-700 text-base">
-                      <span class="material-symbols-outlined text-blue-500 mr-2">check_circle</span>
-                      <%= item.name %>
-                    </li>
-                  <% end %>
-                </ul>
+    <!-- 投稿画像 + 内容：スマホとPCで切り替え -->
+    <!-- スマホのみ表示 -->
+    <div class="block md:hidden">
+      <% if @review.images.attached? %>
+      <div class="swiper-container">
+        <div class="swiper w-full rounded-lg overflow-hidden mb-4">
+          <div class="swiper-wrapper">
+            <% @review.images.each do |image| %>
+              <div class="swiper-slide flex justify-center items-center bg-white">
+                <%= link_to url_for(image), data: { lightbox: "review-images" } do %>
+                  <%= image_tag image.variant(resize_to_limit: [600, 600]), class: "max-h-[300px] w-auto mx-auto object-contain" %>
+                <% end %>
               </div>
             <% end %>
           </div>
         </div>
-
-
-        <!-- PC表示（画像＋サムネイル＋本文） -->
-        <div class="hidden md:flex flex-row gap-6" data-controller="image-gallery">
-          <!-- 左側：画像・サムネイル -->
-          <div class="w-1/2 flex flex-col items-start">
-            <% if @review.images.attached? %>
-              <!-- メイン画像 -->
-              <img data-image-gallery-target="main"
-                  src="<%= url_for(@review.images.first.variant(resize_to_limit: [600, 600])) %>"
-                  class="w-full max-h-[400px] object-contain rounded-md mb-4">
-
-              <!-- サムネイル -->
-              <div class="flex gap-2 overflow-x-auto">
-                <div class="flex gap-2 overflow-x-auto">
-                  <% @review.images.each_with_index do |image, index| %>
-                    <img src="<%= url_for(image.variant(resize_to_fill: [100, 100])) %>"
-                        data-image-gallery-target="thumbnail"
-                        data-action="click->image-gallery#change"
-                        data-large="<%= url_for(image.variant(resize_to_limit: [600, 600])) %>"
-                        data-index="<%= index %>"
-                        class="w-20 h-20 object-cover rounded-md cursor-pointer
-                                transition duration-150 ease-in-out">
-                  <% end %>
-                </div>
-              </div>
-            <% end %>
-          </div>
-
-          <!-- 右側：本文や手放せるもの -->
-          <div class="w-1/2">
-            <h1 class="text-2xl font-bold mb-4 text-gray-800"><%= @review.title %></h1>
-            <div class="text-base text-gray-700 mb-6">
-              <%= simple_format(@review.content) %>
-            </div>
-
-            <% if @review.releasable_items.present? %>
-              <div class="p-4 bg-gray-100 rounded-md">
-                <h2 class="text-lg font-semibold mb-2">手放せるもの</h2>
-                <ul class="space-y-2">
-                  <% @review.releasable_items.each do |item| %>
-                    <li class="flex items-center text-gray-700 text-lg">
-                      <span class="material-symbols-outlined text-blue-500 mr-2">check_circle</span>
-                      <%= item.name %>
-                    </li>
-                  <% end %>
-                </ul>
-              </div>
-            <% end %>
-          </div>
-        </div>
-
+        <div class="swiper-pagination"></div>
       </div>
+      <% end %>
+      <%= render "review_body", review: @review %>
     </div>
 
+    <!-- PCのみ表示 -->
+    <% if @review.images.attached? %>
+      <!-- PC表示：画像あり（2カラム） -->
+      <div class="hidden md:flex flex-row gap-6" data-controller="image-gallery">
+        <!-- 左側：画像・サムネイル -->
+        <div class="w-1/2 flex flex-col items-start">
+          <!-- メイン画像 -->
+          <img data-image-gallery-target="main"
+              src="<%= url_for(@review.images.first.variant(resize_to_limit: [600, 600])) %>"
+              class="w-full max-h-[400px] object-contain rounded-md mb-4">
 
+          <!-- サムネイル -->
+          <div class="flex gap-2 overflow-x-auto">
+            <div class="flex gap-2 overflow-x-auto">
+              <% @review.images.each_with_index do |image, index| %>
+                <img src="<%= url_for(image.variant(resize_to_fill: [100, 100])) %>"
+                    data-image-gallery-target="thumbnail"
+                    data-action="click->image-gallery#change"
+                    data-large="<%= url_for(image.variant(resize_to_limit: [600, 600])) %>"
+                    data-index="<%= index %>"
+                    class="w-20 h-20 object-cover rounded-md cursor-pointer
+                            transition duration-150 ease-in-out">
+              <% end %>
+            </div>
+          </div>
+        </div>
 
+        <!-- 右側：本文など -->
+        <div class="w-1/2">
+          <%= render "review_body", review: @review %>
+        </div>
+      </div>
+    <% else %>
+      <!-- PC表示：画像なし（左寄せ） -->
+      <div class="hidden md:block">
+        <div class="max-w-3xl ml-0">
+          <%= render "review_body", review: @review %>
+        </div>
+      </div>
+    <% end %>
 
     <!-- 編集・削除ボタン -->
     <% if current_user == @review.user %>


### PR DESCRIPTION
### **概要**

下記2コミットの内容をまとめたものです。

- [cfe9715a54d55898acc2bf674120a27e00b7e255](https://github.com/taka292/minire/commit/cfe9715a54d55898acc2bf674120a27e00b7e255):
    
    画像ギャラリー機能の実装、Swiperカルーセルの導入、レビュー詳細ページのレイアウト改善。
    
- [b056343c760472c1847410356ef198e9f120fa7c](https://github.com/taka292/minire/commit/b056343c760472c1847410356ef198e9f120fa7c):
    
    画像ギャラリー等の表示スタイルをさらに改善し、テンプレート部品（`_review_body.html.erb`）を切り出して可読性を向上。
    

---

### **主な修正・追加内容**

- 画像ギャラリー（PC: サムネイル切替・拡大、スマホ: Swiperカルーセル＋Lightbox）を実装
- Swiper/Lightbox2ライブラリの導入および初期化スクリプト追加
- レビュー詳細ページのレイアウトをスマホ/PCで最適化
    - PC: 画像＋テキスト2カラム表示
    - スマホ: カルーセル＋本文下表示
- CSS（Tailwind等）による画像・カルーセルの細かなスタイル改善
- `_review_body.html.erb`テンプレートを共通化し、コード重複を削減
- 表示崩れやレイアウト調整のためのリファクタリング

---

### **影響範囲**

- レビュー詳細ページ（`app/views/reviews/show.html.erb`、`_review_body.html.erb`）
- フロントエンド（画像カルーセル、モバイル/PC切替、スタイル）
- JavaScript（Swiper初期化コードほか）