### PR TITLE
fix : jQueryとLightboxのスクリプトを移動し、読み込み順序を最適化

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -38,17 +38,7 @@
     <!-- JavaScript -->
     <link rel="preload" href="/assets/application-33583849.js" as="script" crossorigin="anonymous">
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module", defer: true, crossorigin: "anonymous" %>
-
-    
     <link href="https://cdnjs.cloudflare.com/ajax/libs/lightbox2/2.11.3/css/lightbox.min.css" rel="stylesheet">
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/lightbox2/2.11.3/js/lightbox.min.js" defer></script>
-    <script>
-    lightbox.option({
-      'resizeDuration': 200,
-      'wrapAround': true
-    })
-    </script>
     <link rel="stylesheet" href="https://unpkg.com/swiper/swiper-bundle.min.css">
   </head>
   <body class="font-sans">
@@ -90,6 +80,16 @@
         once: true,
         offset: 60
       });
+    </script>
+
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/lightbox2/2.11.3/js/lightbox.min.js"></script>
+
+    <script>
+      lightbox.option({
+        'resizeDuration': 200,
+        'wrapAround': true
+      })
     </script>
 
     <script src="https://unpkg.com/swiper/swiper-bundle.min.js"></script>


### PR DESCRIPTION
### **概要**

- jQueryおよびLightbox2の読み込みスクリプトを`<body>`直前に移動し、読み込み順序を最適化しました。
- これにより、Lightboxの初期化タイミングや依存関係に起因する不具合の防止・パフォーマンス向上を図ります。

---

### **主な変更ファイル**

- `app/views/layouts/application.html.erb`
    - `<head>`内に記述されていたjQuery・Lightbox2用スクリプトを、`<body>`の末尾直前に移動
    - Lightboxの初期化スクリプトも同様に移動

---

### **コミット**

- [33fb09e73354af6c85158515a3e73f640ee62f83](https://github.com/taka292/minire/commit/33fb09e73354af6c85158515a3e73f640ee62f83)