### PR TITLE
ui: 商品画像表示をレビュー画像と同様に拡大・タイル表示できるように変更

### DIFF
--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -6,29 +6,50 @@
   <div class="max-w-6xl mx-auto bg-white px-6 sm:px-8 py-6 sm:py-8 shadow-md rounded-md space-y-8">
     <!-- 商品詳細セクション -->
     <div class="flex flex-col md:flex-row gap-8 sm:gap-12 items-start">
-
-      <!-- 左側: 商品画像 (横スクロール) -->
+      <!-- 左側: 商品画像-->
       <div class="w-full md:w-1/2">
+        <!-- スマホ表示：スライド -->
+        <div class="block md:hidden">
           <% if @item.images.attached? %>
-            <p class="text-sm text-gray-500 mb-2 ml-1">
-              ※ 画像は横にスライドできます →
-            </p>
-        <% end %>
-
-        <div class="flex space-x-4 p-2  overflow-x-auto">
-          <% if @item.images.attached? %>
-            <% @item.images.each do |image| %>
-              <img src="<%= url_for(image) %>" alt="<%= @item.name %>" 
-                   class="object-cover rounded-md shadow-md flex-shrink-0">
-            <% end %>
-          <% else %>
-
-              <div class="relative w-[300px] h-[250px] bg-gray-200 border border-gray-300 rounded-md shadow-md flex-shrink-0">
-                <div class="absolute inset-0 flex items-center justify-center text-gray-500 text-lg font-semibold">
-                  画像未登録
+            <div class="swiper-container">
+              <div class="swiper w-full rounded-lg overflow-hidden mb-4">
+                <div class="swiper-wrapper">
+                  <% @item.images.each do |image| %>
+                    <div class="swiper-slide flex justify-center items-center bg-white">
+                      <%= link_to url_for(image), data: { lightbox: "item-images" } do %>
+                        <%= image_tag image.variant(resize_to_limit: [600, 600]), class: "max-h-[300px] w-auto mx-auto object-contain" %>
+                      <% end %>
+                    </div>
+                  <% end %>
                 </div>
               </div>
+              <div class="swiper-pagination"></div>
+            </div>
+          <% else %>
+            <div class="w-full h-[250px] bg-gray-200 flex items-center justify-center rounded-md text-gray-500">画像未登録</div>
+          <% end %>
+        </div>
 
+        <!-- PC表示：タイル + メイン画像 -->
+        <div class="hidden md:flex flex-col" data-controller="image-gallery">
+          <% if @item.images.attached? %>
+            <img data-image-gallery-target="main"
+                 src="<%= url_for(@item.images.first.variant(resize_to_limit: [600, 600])) %>"
+                 class="w-full max-h-[400px] object-contain rounded-md mb-4">
+
+            <div class="flex gap-2 overflow-x-auto">
+              <% @item.images.each_with_index do |image, index| %>
+                <img src="<%= url_for(image.variant(resize_to_fill: [100, 100])) %>"
+                     data-image-gallery-target="thumbnail"
+                     data-action="click->image-gallery#change"
+                     data-large="<%= url_for(image.variant(resize_to_limit: [600, 600])) %>"
+                     data-index="<%= index %>"
+                     class="w-20 h-20 object-cover rounded-md cursor-pointer
+                            transition duration-150 ease-in-out">
+              <% end %>
+            </div>
+          <% else %>
+            <div class="w-full h-[250px] bg-gray-200 flex items-center justify-center rounded-md text-gray-500">画像未登録</div>
           <% end %>
         </div>
       </div>


### PR DESCRIPTION
### **概要**

- 商品詳細ページの商品画像表示を、レビュー画像と同様に「拡大表示（Lightbox）」と「タイル（サムネイル）切替」対応に変更しました。
- スマホはスワイプカルーセル＋Lightbox、PCはサムネイルタイル＋メイン画像＋LightboxのUIです。

---

### **主な変更内容**

- `app/views/items/show.html.erb`
    - 商品画像が複数添付されている場合、スマホはSwiperカルーセル＋Lightbox、PCはサムネイルクリックでメイン画像切替＋Lightbox拡大が可能に
    - 画像未登録時は共通の「画像未登録」表示を最適化

---

### **コミット**

- [852119ac952c036e1ba236e5f9365031d8d6707b](https://github.com/taka292/minire/commit/852119ac952c036e1ba236e5f9365031d8d6707b)