### PR TITLE
ui: 商品詳細とレビュー詳細ページのサムネイル表示を2枚以上ある時に表示するように変更

### DIFF
--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -33,21 +33,25 @@
         <!-- PC表示：タイル + メイン画像 -->
         <div class="hidden md:flex flex-col" data-controller="image-gallery">
           <% if @item.images.attached? %>
+            <!-- メイン画像 -->
             <img data-image-gallery-target="main"
                  src="<%= url_for(@item.images.first.variant(resize_to_limit: [600, 600])) %>"
                  class="w-full max-h-[400px] object-contain rounded-md mb-4">
 
-            <div class="flex gap-2 overflow-x-auto">
-              <% @item.images.each_with_index do |image, index| %>
-                <img src="<%= url_for(image.variant(resize_to_fill: [100, 100])) %>"
-                     data-image-gallery-target="thumbnail"
-                     data-action="click->image-gallery#change"
-                     data-large="<%= url_for(image.variant(resize_to_limit: [600, 600])) %>"
-                     data-index="<%= index %>"
-                     class="w-20 h-20 object-cover rounded-md cursor-pointer
-                            transition duration-150 ease-in-out">
-              <% end %>
-            </div>
+            <!-- サムネイル -->
+            <% if @item.images.size >= 2 %>
+              <div class="flex gap-2 overflow-x-auto">
+                <% @item.images.each_with_index do |image, index| %>
+                  <img src="<%= url_for(image.variant(resize_to_fill: [100, 100])) %>"
+                      data-image-gallery-target="thumbnail"
+                      data-action="click->image-gallery#change"
+                      data-large="<%= url_for(image.variant(resize_to_limit: [600, 600])) %>"
+                      data-index="<%= index %>"
+                      class="w-20 h-20 object-cover rounded-md cursor-pointer
+                              transition duration-150 ease-in-out">
+                <% end %>
+              </div>
+            <% end %>
           <% else %>
             <div class="w-full h-[250px] bg-gray-200 flex items-center justify-center rounded-md text-gray-500">画像未登録</div>
           <% end %>

--- a/app/views/reviews/show.html.erb
+++ b/app/views/reviews/show.html.erb
@@ -71,19 +71,19 @@
               class="w-full max-h-[400px] object-contain rounded-md mb-4">
 
           <!-- サムネイル -->
-          <div class="flex gap-2 overflow-x-auto">
+          <% if @review.images.size >= 2 %>
             <div class="flex gap-2 overflow-x-auto">
-              <% @review.images.each_with_index do |image, index| %>
-                <img src="<%= url_for(image.variant(resize_to_fill: [100, 100])) %>"
-                    data-image-gallery-target="thumbnail"
-                    data-action="click->image-gallery#change"
-                    data-large="<%= url_for(image.variant(resize_to_limit: [600, 600])) %>"
-                    data-index="<%= index %>"
-                    class="w-20 h-20 object-cover rounded-md cursor-pointer
-                            transition duration-150 ease-in-out">
-              <% end %>
+                <% @review.images.each_with_index do |image, index| %>
+                  <img src="<%= url_for(image.variant(resize_to_fill: [100, 100])) %>"
+                      data-image-gallery-target="thumbnail"
+                      data-action="click->image-gallery#change"
+                      data-large="<%= url_for(image.variant(resize_to_limit: [600, 600])) %>"
+                      data-index="<%= index %>"
+                      class="w-20 h-20 object-cover rounded-md cursor-pointer
+                              transition duration-150 ease-in-out">
+                <% end %>
             </div>
-          </div>
+          <% end %>
         </div>
 
         <!-- 右側：本文など -->


### PR DESCRIPTION
### **概要**

- 商品詳細ページとレビュー詳細ページで、画像サムネイルの表示条件を「画像が2枚以上の場合のみ表示」に変更しました。
    - 画像が1枚のみの場合はサムネイルが表示されなくなり、UIの無駄なスペースを排除しました。

---

### **主な変更ファイル**

- `app/views/items/show.html.erb`
    - 商品画像のサムネイル表示部分に `@item.images.size >= 2` の条件を追加
- `app/views/reviews/show.html.erb`
    - レビュー画像のサムネイル表示部分に `@review.images.size >= 2` の条件を追加

---

### **コミット**

- [41198e4fd70af5f39de93ba56c1091bc54f885e3](https://github.com/taka292/minire/commit/41198e4fd70af5f39de93ba56c1091bc54f885e3)