### PR TITLE
fix: ログイン保持機能を強化し、ログイン画面のテキスト表示も改善

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  # deviseのログイン保持機能を読み込み
+  include Devise::Controllers::Rememberable
+
   # callback for google
   def google_oauth2
     callback_for(:google)
@@ -10,7 +13,9 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     auth = request.env["omniauth.auth"]
     @user = User.from_omniauth(auth)
 
+    # SNSログインに成功した場合、ログイン保持状態をON
     if @user.persisted?
+      remember_me(@user)
       flash[:notice] = "Google認証成功しました！さっそくレビューを投稿してみませんか？" unless @user.has_reviews?
       sign_in_and_redirect @user, event: :authentication
     else

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -30,7 +30,7 @@
             <label class="label">
               <span class="label-text text-base font-medium">メールアドレス</span>
             </label>
-            <!--フォーム入力でエラーがあれば赤枠で囲む-->
+            <%# フォーム入力でエラーがあれば赤枠で囲む %>
             <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "メールアドレスを入力してください", class: "input input-bordered w-full h-14 text-base placeholder:text-sm #{'border-red-500' if flash[:alert].present?}" %>
           </div>
           <div class="form-control mb-4">
@@ -40,11 +40,12 @@
             <%= f.password_field :password, autocomplete: "current-password", placeholder: "パスワードを入力してください", class: "input input-bordered w-full h-14 text-base placeholder:text-sm #{'border-red-500' if flash[:alert].present?}" %>
           </div>
 
+          <%# ログイン状態を保持するチェックボックス(デフォルトでログイン状態保持) %>
           <% if devise_mapping.rememberable? %>
             <div class="form-control mb-4">
-              <label class="label cursor-pointer flex items-center">
-                <%= f.check_box :remember_me, class: "checkbox mr-2" %>
-                <span class="label-text text-base font-medium">ログイン状態を保持する</span>
+              <label class="cursor-pointer flex">
+                <%= f.check_box :remember_me, class: "checkbox", checked: true %>
+                <span class="label-text text-base font-medium ml-4">ログイン状態を保持する</span>
               </label>
             </div>
           <% end %>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -164,13 +164,15 @@ Devise.setup do |config|
 
   # ==> Configuration for :rememberable
   # The time the user will be remembered without asking for credentials again.
-  # config.remember_for = 2.weeks
+  # ログイン保持期間
+  config.remember_for = 1.month
 
   # Invalidates all the remember me tokens when the user signs out.
   config.expire_all_remember_me_on_sign_out = true
 
   # If true, extends the user's remember period when remembered via cookie.
-  # config.extend_remember_period = false
+  # ログイン保持かつ、再度アクセスした際に、ログイン保持期間追加
+  config.extend_remember_period = true
 
   # Options to be passed to the created cookie. For instance, you can set
   # secure: true in order to force SSL only cookies.
@@ -188,7 +190,8 @@ Devise.setup do |config|
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.
-  # config.timeout_in = 30.minutes
+  # ログイン保持を押さなかったときに、セッションが切れる時間指定
+  config.timeout_in = 1.hour
 
   # ==> Configuration for :lockable
   # Defines which strategy will be used to lock an account.

--- a/spec/system/comment_spec.rb
+++ b/spec/system/comment_spec.rb
@@ -90,6 +90,8 @@ RSpec.describe "コメント機能", type: :system do
     it "ログアウト状態ではコメント一覧が表示されない" do
       review.comments.create!(content: "表示されないはずのコメント", user: user)
       logout
+      # テストだとcookieが残ってしまうので、意図的に削除
+      page.driver.browser.manage.delete_all_cookies
       visit review_path(review)
 
       expect(page).not_to have_content("表示されないはずのコメント")

--- a/spec/system/like_spec.rb
+++ b/spec/system/like_spec.rb
@@ -37,6 +37,8 @@ RSpec.describe "いいね機能", type: :system do
 
     it "ログアウト状態ではいいねできない" do
       logout
+      # テストだとcookieが残ってしまうので、意図的に削除
+      page.driver.browser.manage.delete_all_cookies
       visit review_path(review)
 
       within("#like_button_#{review.id}") do


### PR DESCRIPTION
## 概要
ログイン画面の「次回から自動的にログイン」に関する初期状態の修正およびUIの微調整を行いました。

## 主な変更内容

- 「次回から自動的にログイン」(Remember me) チェックボックスのデフォルト状態をONにしました。
- ログイン画面のUIを調整し、ユーザーにとってより使いやすいデザインに改善しました。
- ログイン保持設定を追加し、ログイン保持チェックだと1ヶ月ログイン状態が続き、再度アクセス日するとログイン状態をその日から追加する。また、ログイン保持チェックoffだと1時間でログインが切れるように設定。(SNSログインでも同様)
- 細かなスタイルやレイアウトの調整を実施しました。

## 目的

- 自動ログイン状態をデフォルトにして、さらにスムーズな使用にするため。

## 関連コミット

- 83442e497f309beb3276374106327a7235b20720