### PR TITLE
Feature/247 UI adjustments

### DIFF
--- a/app/controllers/amazon_controller.rb
+++ b/app/controllers/amazon_controller.rb
@@ -1,8 +1,9 @@
 class AmazonController < ApplicationController
   # Amazonの商品検索結果を返す
   def index
-    # 5文字未満 or 空白の場合は検索しない(リクエストを無駄にしないため)
-    return render plain: "", status: :ok if params[:q].blank? || params[:q].strip.size < 6
+    # 5文字未満 or 201文字以上 or 空白の場合は検索しない(リクエストを無駄にしないため)
+    query = params[:q].to_s.strip
+    return render plain: "", status: :ok if query.blank? || query.size < 6 || query.size > 200
 
     # Amazon APIを使って商品検索
     amazon = AmazonApiClient.new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,9 +1,7 @@
 class ItemsController < ApplicationController
   def index
     @items = Item.where("name LIKE ?", "%#{params[:q]}%")
-    respond_to do |format|
-      format.js
-    end
+    render layout: false
   end
 
   def show

--- a/app/views/amazon/index.html.erb
+++ b/app/views/amazon/index.html.erb
@@ -13,7 +13,7 @@
     <% end %>
 
     <span class="text-gray-800 leading-snug">
-      <%= truncate(label, length: 50) %>
+      <%= label %>
     </span>
   </li>
 <% end %>


### PR DESCRIPTION
## 概要
Amazon商品検索・補完機能のUI改善およびロジック整理を行いました。主に候補表示・入力バリデーション・不要処理の削除など、実用性向上のための対応です。

## 主な変更内容

- 商品候補表示名のトランケート（省略表示）処理を削除し、候補名をそのまま表示
  - [70d898afc278990821194547f3e3f5a2eb513eb1](https://github.com/taka292/minire/commit/70d898afc278990821194547f3e3f5a2eb513eb1)
    - `app/views/amazon/index.html.erb` のラベル表示を `truncate(label, length: 50)` → `label` に変更

- 商品名検索時に「長すぎる商品名」の入力を無効化
  - [bd6c65f7b7083865697579674ce962a2bc5a93a0](https://github.com/taka292/minire/commit/bd6c65f7b7083865697579674ce962a2bc5a93a0)
    - `app/controllers/amazon_controller.rb`  
      5文字未満または201文字以上、空白のクエリの場合は検索しないようバリデーションを強化

- 商品名が見つからない場合の不要な `respond_to` ブロックを削除し、Amazon商品名表示ロジックに合わせて `render layout: false` に統一
  - [e77a2f4de05c5042459bb4243040f0cf185b3d2b](https://github.com/taka292/minire/commit/e77a2f4de05c5042459bb4243040f0cf185b3d2b)
    - `app/controllers/items_controller.rb`  
      `respond_to` の削除、`render layout: false` へ変更

## 目的

- Amazon商品検索のユーザビリティおよび保守性向上
- 不要・冗長な処理の整理
- 検索入力バリデーションの強化

## 対象コミット

- [70d898afc278990821194547f3e3f5a2eb513eb1](https://github.com/taka292/minire/commit/70d898afc278990821194547f3e3f5a2eb513eb1)
- [bd6c65f7b7083865697579674ce962a2bc5a93a0](https://github.com/taka292/minire/commit/bd6c65f7b7083865697579674ce962a2bc5a93a0)
- [e77a2f4de05c5042459bb4243040f0cf185b3d2b](https://github.com/taka292/minire/commit/e77a2f4de05c5042459bb4243040f0cf185b3d2b)

---

ご確認よろしくお願いいたします。