### PR TITLE
ui: コメントフォームのプレースホルダーと送信ボタンのテキストを編集・新規作成に応じて変更

### DIFF
--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -4,10 +4,10 @@
       <div class="form-control mb-2 mt-2">
         <%= form.text_area :content, 
           class: "textarea textarea-bordered w-full text-lg placeholder:text-sm", 
-          placeholder: "コメントする" %>
+          placeholder: comment.persisted? ? "コメントを編集する" : "コメントする" %>
       </div>
       <div class="text-right mt-2">
-        <%= form.submit "コメント", class: "btn bg-customBlue text-white border-0 hover:bg-blue-500 btn-sm inline-block align-middle"%>
+        <%= form.submit comment.persisted? ? "更新する" : "コメントする", class: "btn bg-customBlue text-white border-0 hover:bg-blue-500 btn-sm inline-block align-middle"%>
       </div>
     <% end %>
   <% end %>

--- a/spec/system/comment_spec.rb
+++ b/spec/system/comment_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe "コメント機能", type: :system do
       # 編集フォームのTurbo Frame内で内容を書き換えて投稿
       within("#comment_#{comment.id}_form") do
         fill_in "comment_content", with: "編集後のコメント"
-        click_button "コメント"
+        click_button "更新する"
       end
 
       # 編集後の内容が表示され、古い内容は消えていることを確認


### PR DESCRIPTION
## 概要
コメントフォームのプレースホルダーおよび送信ボタンのテキストを、コメントの「編集」もしくは「新規作成」に応じて動的に変更しました。

## 主な変更内容

- コメントが既存の場合（編集時）は、プレースホルダーを「コメントを編集する」、ボタンを「更新する」に表示変更
- 新規作成時は、従来通り「コメントする」で表示

### 対象ファイル
- `app/views/comments/_form.html.erb`

## 目的

- コメント操作時のUI/UX向上
- 編集と新規作成の区別をユーザーにわかりやすくするため

## 参考コミット

- [f340daed9478613117059400c498071bb5c37cfc](https://github.com/taka292/minire/commit/f340daed9478613117059400c498071bb5c37cfc)
