### PR TITLE
Feature/260 refactor code cleanup

### DIFF
--- a/app/views/reviews/show.html.erb
+++ b/app/views/reviews/show.html.erb
@@ -16,6 +16,8 @@
 <%#パンくずリスト %>
 <% breadcrumb :review, @review %>
 
+<% has_images = @review.images.attached? %>
+
 <div class="container mx-auto px-4 py-8">
   <!-- 投稿詳細カード -->
   <div class="card bg-white shadow-lg rounded-lg p-6">
@@ -40,7 +42,7 @@
     <!-- 投稿画像 + 内容：スマホとPCで切り替え -->
     <!-- スマホのみ表示 -->
     <div class="block md:hidden">
-      <% if @review.images.attached? %>
+      <% if has_images %>
       <div class="swiper-container">
         <div class="swiper w-full rounded-lg overflow-hidden mb-4">
           <div class="swiper-wrapper">
@@ -60,7 +62,7 @@
     </div>
 
     <!-- PCのみ表示 -->
-    <% if @review.images.attached? %>
+    <% if has_images %>
       <!-- PC表示：画像あり（2カラム） -->
       <div class="hidden md:flex flex-row gap-6" data-controller="image-gallery">
         <!-- 左側：画像・サムネイル -->

--- a/app/views/shared/_review_card.html.erb
+++ b/app/views/shared/_review_card.html.erb
@@ -26,10 +26,8 @@
 
       <!-- 投稿写真 -->
       <div class="mb-4 grid grid-cols-3 gap-3">
-        <% if review.images.attached? %>
-          <% review.resized_images.take(3).each do |image| %>
-            <%= image_tag image, alt: "投稿写真", class: "aspect-square rounded-md col-span-1 object-cover" %>
-          <% end %>
+        <% review.resized_images.take(3).each do |image| %>
+          <%= image_tag image, alt: "投稿写真", class: "aspect-square rounded-md col-span-1 object-cover" %>
         <% end %>
       </div>
     <% end %>

--- a/app/views/shared/_review_list.html.erb
+++ b/app/views/shared/_review_list.html.erb
@@ -9,16 +9,17 @@
 
       <%#  検索クエリを保持する hidden フィールド(ないと絞り込みフォームと合わせての検索ができない) %>
       <%= hidden_field_tag "q[#{review_search_field}]", params.dig(:q, review_search_field) %>
+
       <!-- 絞り込みフォーム -->
-      <div class="flex flex-col md:flex-row  min-w-[300px]">
+      <div class="flex flex-col md:flex-row min-w-[300px]">
         <label for="filter_type" class="text-sm font-medium text-gray-600 whitespace-nowrap min-w-fit md:mr-2">絞り込み:</label>
         <select name="filter_type" id="filter_type"
                 class="min-w-[250px] max-w-full h-12 text-base pl-4 pr-4 bg-gray-50 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-400 focus:border-blue-400 transition duration-200 flex-grow"
                 onchange="this.form.submit()">
-          <option value="" <%= "selected='selected'" if params[:filter_type].blank? %>>すべてのレビュー</option>
-          <option value="releasable" <%= "selected='selected'" if params[:filter_type] == 'releasable' %>>手放せるものがあるレビュー</option>
+          <option value="" <%= 'selected' if params[:filter_type].blank? %>>すべてのレビュー</option>
+          <option value="releasable" <%= 'selected' if params[:filter_type] == 'releasable' %>>手放せるものがあるレビュー</option>
           <% @categories.each do |category| %>
-            <option value="category_<%= category.id %>" <%= "selected='selected'" if params[:filter_type] == "category_#{category.id}" %>>
+            <option value="category_<%= category.id %>" <%= 'selected' if params[:filter_type] == "category_#{category.id}" %>>
               カテゴリ: <%= category.name %>
             </option>
           <% end %>
@@ -31,9 +32,9 @@
         <select name="sort" id="sort"
                 class="min-w-[150px] max-w-full h-12 text-base pl-4 pr-4 bg-gray-50 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-400 focus:border-blue-400 transition duration-200 flex-grow"
                 onchange="this.form.submit()">
-          <option value="newest" <%= "selected='selected'" if params[:sort] == 'newest' %>>新着順</option>
-          <option value="oldest" <%= "selected='selected'" if params[:sort] == 'oldest' %>>古い順</option>
-          <option value="most_liked" <%= "selected='selected'" if params[:sort] == 'most_liked' %>>いいねが多い順</option>
+          <option value="newest" <%= 'selected' if params[:sort] == 'newest' %>>新着順</option>
+          <option value="oldest" <%= 'selected' if params[:sort] == 'oldest' %>>古い順</option>
+          <option value="most_liked" <%= 'selected' if params[:sort] == 'most_liked' %>>いいねが多い順</option>
         </select>
       </div>
 


### PR DESCRIPTION
## 概要
レビュー関連のUI・ロジックを中心に、コードの簡素化・リファクタリングを行いました。主に選択状態や画像表示の判定処理を整理し、可読性・保守性を向上させています。

## 主な変更内容

- レビューリスト：絞り込みフォームやソートの選択状態判定をシンプルな記法に統一
  - `'selected="selected"'` → `'selected'` へ変更し、記述を簡素化
  - 対象ファイル: `app/views/shared/_review_list.html.erb`
  - [83687cd9d8a8327f3605e45d2baed6f80177766f](https://github.com/taka292/minire/commit/83687cd9d8a8327f3605e45d2baed6f80177766f)

- レビュー詳細：画像の有無判定を変数化し、複数箇所で共通利用することでコードを簡素化
  - `@review.images.attached?` の判定を `has_images` 変数に格納
  - 対象ファイル: `app/views/reviews/show.html.erb`
  - [b4f3f9c2a34da248b8802a2bb327659f739e58d2](https://github.com/taka292/minire/commit/b4f3f9c2a34da248b8802a2bb327659f739e58d2)

- レビュー一覧カード：投稿写真表示ロジックを簡素化し、不要なif文を削除
  - `review.images.attached?` の判定を省略し、画像が無い場合はeachがスキップされるように
  - 対象ファイル: `app/views/shared/_review_card.html.erb`
  - [96190605185f4d4b7dfeab1c73f63d1df7ce3d99](https://github.com/taka292/minire/commit/96190605185f4d4b7dfeab1c73f63d1df7ce3d99)

## 目的

- コードの可読性・保守性の向上
- UIロジックの統一・簡素化
