### PR TITLE
ui : 下書き保存ボタンの色を直接指定し、下書き一覧モーダルの最大幅をフォーム幅にあわせて調整

### DIFF
--- a/app/views/reviews/_draft_section.erb
+++ b/app/views/reviews/_draft_section.erb
@@ -2,7 +2,7 @@
   <!-- 下書き保存ボタン -->
   <div class="w-full">
     <%= form.submit "下書き保存", name: "draft",
-          class: "btn bg-gray-400 text-white border-0 hover:bg-gray-500 px-6 py-2 text-base w-full", data: { action: "click->loading#show" } %>
+          class: "btn text-white border-0 px-6 py-2 text-base w-full", data: { action: "click->loading#show", mouseout: "this.style.backgroundColor='#9CA3AF'" }, style: "background-color: #9CA3AF;", onmouseover: "this.style.backgroundColor='#6B7280';", onmouseout: "this.style.backgroundColor='#9CA3AF';" %>
   </div>
   <!-- 下書きモーダルトリガー -->
   <div class="w-full">
@@ -11,7 +11,7 @@
 
   <!-- 下書き一覧モーダル -->
   <div id="draftModal" class="fixed inset-0 z-50 bg-black bg-opacity-40 hidden items-center justify-center">
-    <div class="bg-white w-full max-w-2xl mx-auto p-6 rounded-lg shadow-xl">
+    <div class="bg-white w-full max-w-4xl mx-auto p-6 rounded-lg shadow-xl">
       <h2 class="text-lg font-semibold mb-4">下書き一覧</h2>
 
       <div class="space-y-4 max-h-80 overflow-y-auto">


### PR DESCRIPTION
## 概要

下書き保存ボタンの色指定方法を直接スタイル指定に変更し、ホバー時の色変更もJSで制御するように修正しました。また、下書き一覧モーダルの最大幅をフォームに合わせて大きく調整し、UIの一体感と見やすさを向上させました。

## 主な変更点

- 下書き保存ボタン
  - `bg-gray-400` などのクラス指定を廃止し、`style`属性で直接背景色を指定
  - ホバー時の色変更も `onmouseover` / `onmouseout` でJS制御
  ※tailwind cssのスタイルが適用されなかったため
- 下書き一覧モーダル
  - 最大幅（`max-w-2xl` → `max-w-4xl`）に拡大し、フォーム幅と統一

## 対象コミット

- [c8dc4ad4b48dd2be83ab87370391b58fcc65dba9](https://github.com/taka292/minire/commit/c8dc4ad4b48dd2be83ab87370391b58fcc65dba9)